### PR TITLE
2025.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2025.6.2] - 2025-07-07
+### Added
+- `enabled_by_default: false` set for all sensors except key ones (e.g. voltage, current, SOC)
+- Example Lovelace dashboard added to the integration folder
+- Support for Modbus `int32` and `char` register types
+
+### Changed
+- Select, Number, and Switch entities now implement `async_update()` and reflect real device state
+- Improved state mapping for sensors using `states` dictionary
+
+### Fixed
+- Correct mapping of 'Trade Mode' (value 2) in select register
+- All switch and number entities now generate truly unique IDs per integration instance
+
 ## [2025.6.1] - 2025-07-07
 ### Added
 - Combined alarm sensor decoding multiple alarm bits into one entity

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO List
 
-- [ ] Update documentation
+- [x] Update documentation
 - [ ] Update poll interval via GUI
 - [ ] Fix for int32/char handling 
 - [ ] Use device_name as device name in Home Assistant

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,10 @@
 
 - [x] Update documentation
 - [ ] Update poll interval via GUI
-- [ ] Fix for int32/char handling 
+- [x] Fix for int32/char handling 
 - [ ] Use device_name as device name in Home Assistant
 - [ ] Fix icon display in HACS
 - [ ] Improve HACS documentation and visibility
+- [ ] Add all relevant Modbus sensors with `enabled_by_default: false`
+- [ ] Enable only key sensors (e.g. voltage, SOC, current, mode) by default
+- [ ] Provide a Lovelace dashboard example in the integration folder

--- a/custom_components/marstek_modbus/config_flow.py
+++ b/custom_components/marstek_modbus/config_flow.py
@@ -3,8 +3,10 @@
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_PORT
-from .const import DOMAIN, DEFAULT_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
+from homeassistant.helpers.translation import async_get_translations
+from homeassistant.helpers.selector import selector
+from .const import DOMAIN, DEFAULT_PORT, SCAN_INTERVAL
 
 class MarstekConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Marstek Venus Modbus integration."""
@@ -15,12 +17,15 @@ class MarstekConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step where the user provides configuration."""
         errors = {}
 
+        translations = await async_get_translations(self.hass, self.language)
+        localize = translations.async_gettext
+
         # If user_input is provided, create the config entry with the given data.
         if user_input is not None:
             # Create a new config entry with the title and user input data.
-            return self.async_create_entry(title="Marstek Venus Modbus", data=user_input)
+            return self.async_create_entry(title=localize("config.step.user.title"), data=user_input)
 
-        # Show the form to the user to collect host and port information.
+        # Show the form to the user to collect host, port, and scan interval information.
         # vol.Schema defines the expected fields and their types for the form.
         return self.async_show_form(
             step_id="user",
@@ -28,5 +33,6 @@ class MarstekConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_HOST): str,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
             }),
+            description_placeholders={},
             errors=errors
         )

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -2,7 +2,6 @@
 DOMAIN = "marstek_modbus"
 
 # Default network configuration for Modbus connection
-DEFAULT_HOST = "192.168.1.100"
 DEFAULT_PORT = 502
 
 # Time interval (in seconds) between data scans

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -20,6 +20,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.host = entry.data["host"]
         self.port = entry.data["port"]
+        self.interval = entry.data.get("scan_interval", SCAN_INTERVAL)
 
         # Initialize and connect the Modbus client to the device
         self.client = MarstekModbusClient(self.host, self.port)
@@ -30,7 +31,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name="Marstek Venus Modbus Coordinator",
-            update_interval=timedelta(seconds=SCAN_INTERVAL),
+            update_interval=timedelta(seconds=self.interval),
         )
 
     async def _async_update_data(self):

--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -69,7 +69,7 @@ class MarstekModbusClient:
             return regs[0]
 
         elif data_type == "int32":
-            val = (regs[1] << 16) | regs[0]  # little endian
+            val = (regs[0] << 16) | regs[1]  # big endian
             return val - 0x100000000 if val >= 0x80000000 else val
 
         elif data_type == "uint32":

--- a/custom_components/marstek_modbus/manifest.json
+++ b/custom_components/marstek_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_modbus",
   "name": "Marstek Venus Modbus",
-  "version": "2025.6.1",
+  "version": "2025.6.2",
   "config_flow": true,
   "documentation": "https://github.com/viperrnmc/marstek_venus_modbus",
   "requirements": ["pymodbus>=3.5.2"],

--- a/custom_components/marstek_modbus/translation/en.json
+++ b/custom_components/marstek_modbus/translation/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Marstek Venus",
+        "title": "Connect to Marstek Venus Modbus",
         "description": "Enter the Modbus TCP connection details",
         "data": {
           "host": "IP Address",

--- a/custom_components/marstek_modbus/translation/nl.json
+++ b/custom_components/marstek_modbus/translation/nl.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Verbind met Marstek Venus Modbus",
+        "description": "Voer de Modbus TCP-verbindingsgegevens in",
+        "data": {
+          "host": "IP-adres",
+          "port": "Poort"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken met het apparaat"
+    },
+    "abort": {
+      "already_configured": "Dit apparaat is al geconfigureerd"
+    }
+  }
+}


### PR DESCRIPTION
## [2025.6.2] - 2025-07-07
### Added
- `enabled_by_default: false` set for all sensors except key ones (e.g. voltage, current, SOC)
- Example Lovelace dashboard added to the integration folder
- Support for Modbus `int32` and `char` register types

### Changed
- Select, Number, and Switch entities now implement `async_update()` and reflect real device state
- Improved state mapping for sensors using `states` dictionary

### Fixed
- Correct mapping of 'Trade Mode' (value 2) in select register
- All switch and number entities now generate truly unique IDs per integration instance