### PR TITLE
2025.6.3

### DIFF
--- a/custom_components/marstek_modbus/__init__.py
+++ b/custom_components/marstek_modbus/__init__.py
@@ -3,7 +3,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import MarstekCoordinator
 
-PLATFORMS = ["sensor", "switch", "number", "select"]
+PLATFORMS = ["sensor", "switch", "number", "select", "button"]
 
 async def async_setup(hass: HomeAssistant, config):
     return True

--- a/custom_components/marstek_modbus/button.py
+++ b/custom_components/marstek_modbus/button.py
@@ -1,0 +1,66 @@
+"""
+This module defines a ButtonEntity for triggering actions on a Marstek Venus battery
+via Modbus register writes.
+"""
+
+# Import necessary components and modules
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from .const import BUTTON_DEFINITIONS, DOMAIN, MANUFACTURER, MODEL
+from .coordinator import MarstekCoordinator
+
+# Set up logging for debugging purposes
+import logging
+_LOGGER = logging.getLogger(__name__)
+
+class MarstekButton(ButtonEntity):
+    """ButtonEntity to trigger actions on the Marstek Venus battery."""
+
+    def __init__(self, coordinator: MarstekCoordinator, definition: dict):
+        """
+        Initialize the button entity with the coordinator and set attributes.
+        This includes the name, unique ID, and register information.
+        """
+        self.coordinator = coordinator
+        self.definition = definition
+        self._attr_name = f"{self.definition['name']}"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{self.definition['key']}"
+        self._attr_has_entity_name = True
+        self._register = self.definition["register"]
+        self._value = self.definition.get("value", 1)  # Default value to write on press
+
+        # Optional: disable entity by default if specified in the button definition
+        if self.definition.get("enabled_by_default") is False:
+            self._attr_entity_registry_enabled_default = False
+
+    async def async_press(self) -> None:
+        """Handle button press by writing the specified value to the Modbus register."""
+        success = self.coordinator.client.write_register(self._register, self._value)
+        if success:
+            _LOGGER.debug("Successfully wrote value %s to register %s on button press", self._value, self._register)
+        else:
+            _LOGGER.warning("Failed to write value %s to register %s on button press", self._value, self._register)
+
+    @property
+    def device_info(self):
+        """Return device information to associate entities with a device in the UI.
+
+        This enables the "Rename associated entities?" dialog when the user renames the integration instance.
+        It also groups all entities under one device in the Home Assistant device registry.
+        """
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
+            "name": self.coordinator.config_entry.title,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL,
+            "entry_type": "service"
+        }    
+
+# Setup function to add the button entities to Home Assistant
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+    """Set up the MarstekButton entities using the provided config entry."""
+    coordinator = MarstekCoordinator(hass, entry)
+    entities = [MarstekButton(coordinator, definition) for definition in BUTTON_DEFINITIONS]
+    async_add_entities(entities)

--- a/custom_components/marstek_modbus/button.py
+++ b/custom_components/marstek_modbus/button.py
@@ -1,47 +1,65 @@
 """
-This module defines a ButtonEntity for triggering actions on a Marstek Venus battery
-via Modbus register writes.
+This module defines a SelectEntity for setting and reading the user work mode
+of a Marstek Venus battery via Modbus register 43000.
 """
 
 # Import necessary components and modules
-from homeassistant.components.button import ButtonEntity
+from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .const import BUTTON_DEFINITIONS, DOMAIN, MANUFACTURER, MODEL
+from .const import SELECT_DEFINITIONS, DOMAIN, MANUFACTURER, MODEL
 from .coordinator import MarstekCoordinator
 
 # Set up logging for debugging purposes
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-class MarstekButton(ButtonEntity):
-    """ButtonEntity to trigger actions on the Marstek Venus battery."""
+class MarstekUserModeSelect(SelectEntity):
+    """SelectEntity to manage the user work mode of the Marstek Venus battery."""
 
     def __init__(self, coordinator: MarstekCoordinator, definition: dict):
         """
-        Initialize the button entity with the coordinator and set attributes.
-        This includes the name, unique ID, and register information.
+        Initialize the select entity with the coordinator and set attributes.
+        This includes the name, unique ID, options, and mapping for the work modes.
         """
         self.coordinator = coordinator
         self.definition = definition
         self._attr_name = f"{self.definition['name']}"
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{self.definition['key']}"
         self._attr_has_entity_name = True
+        self._attr_should_poll = True  # Enable polling to refresh data
+        self._attr_options = self.definition["options"]
+        self._map_to_int = self.definition["map_to_int"]
+        self._int_to_map = self.definition["int_to_map"]
         self._register = self.definition["register"]
-        self._value = self.definition.get("value", 1)  # Default value to write on press
+        self._value = self._attr_options[0]
 
-        # Optional: disable entity by default if specified in the button definition
+        # Optional: disable entity by default if specified in the sensor definition
         if self.definition.get("enabled_by_default") is False:
             self._attr_entity_registry_enabled_default = False
 
-    async def async_press(self) -> None:
-        """Handle button press by writing the specified value to the Modbus register."""
-        success = self.coordinator.client.write_register(self._register, self._value)
-        if success:
-            _LOGGER.debug("Successfully wrote value %s to register %s on button press", self._value, self._register)
-        else:
-            _LOGGER.warning("Failed to write value %s to register %s on button press", self._value, self._register)
+    def select_option(self, option: str) -> None:
+        """Handle selection of a new work mode option and write it to the Modbus register."""
+        int_value = self._map_to_int.get(option)
+        if int_value is not None:
+            success = self.coordinator.client.write_register(self._register, int_value)
+            if success:
+                self._value = option
+
+    async def async_update(self):
+        """Fetch the current work mode from the Modbus register and update the entity state."""
+        raw_value = self.coordinator.client.read_register(register=self._register, data_type="uint16", count=1)
+        if raw_value is not None:
+            if raw_value in self._int_to_map:
+                self._value = self._int_to_map[raw_value]
+            else:
+                _LOGGER.warning("Unknown mode value read from register %s: %s", self._register, raw_value)
+
+    @property
+    def current_option(self):
+        """Return the currently selected work mode option."""
+        return self._value
 
     @property
     def device_info(self):
@@ -58,9 +76,9 @@ class MarstekButton(ButtonEntity):
             "entry_type": "service"
         }    
 
-# Setup function to add the button entities to Home Assistant
+# Setup function to add the select entity to Home Assistant
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
-    """Set up the MarstekButton entities using the provided config entry."""
+    """Set up the MarstekUserModeSelect entity using the provided config entry."""
     coordinator = MarstekCoordinator(hass, entry)
-    entities = [MarstekButton(coordinator, definition) for definition in BUTTON_DEFINITIONS]
+    entities = [MarstekUserModeSelect(coordinator, definition) for definition in SELECT_DEFINITIONS]
     async_add_entities(entities)

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -246,12 +246,40 @@ SELECT_DEFINITIONS = [
             1: "Anti-Feed",
             2: "Trade Mode"
         }
+    },
+    {
+        "name": "Force Mode",
+        "register": 42010,
+        "key": "force_mode",
+        "enabled_by_default": True,
+        "options": ["None", "Charge", "Discharge"],
+        "map_to_int": {
+            "None": 0,
+            "Charge": 1,
+            "Discharge": 2
+        },
+        "int_to_map": {
+            0: "None",
+            1: "Charge",
+            2: "Discharge"
+        }
     }
 ]
 
 # Definitions for switch controls that can be toggled on/off
 # Each switch includes the Modbus register register and commands for on/off
 SWITCH_DEFINITIONS = [
+    {
+        # Battery backup switch
+        "name": "Backup Function",
+        "register": 41200,
+        "command_on": 0,    # Enable
+        "command_off": 1,   # Disable
+        "write_type": "holding",
+        "key": "backup_function",
+        "enabled_by_default": True,
+        "data_type": "uint16"
+    },
     {
         # RS485 communication control mode switch
         "name": "RS485 Control Mode",
@@ -261,27 +289,7 @@ SWITCH_DEFINITIONS = [
         "write_type": "holding",
         "key": "rs485_control_mode",
         "enabled_by_default": True
-    },    
-    {
-        # Force battery charge mode switch
-        "name": "Force Charge Mode",
-        "register": 42010,
-        "command_on": 1,
-        "command_off": 0,
-        "write_type": "holding",
-        "key": "force_charge_mode",
-        "enabled_by_default": False
-    },
-    {
-        # Force battery discharge mode switch
-        "name": "Force Discharge Mode",
-        "register": 42010,
-        "command_on": 2,
-        "command_off": 0,
-        "write_type": "holding",
-        "key": "force_discharge_mode",
-        "enabled_by_default": False
-    }
+    }    
 ]
 
 # Definitions for numeric configuration parameters

--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -103,7 +103,7 @@ class MarstekModbusClient:
             bool: True if write was successful, False otherwise.
         """
         try:
-            result = self.client.write_register(register=register, value=value, slave=self.unit_id)
+            result = self.client.write_register(address=register, value=value, slave=self.unit_id)
             return not result.isError()
         except Exception as e:
             _LOGGER.exception("Exception during modbus write: %s", e)

--- a/custom_components/marstek_modbus/select.py
+++ b/custom_components/marstek_modbus/select.py
@@ -18,13 +18,13 @@ _LOGGER = logging.getLogger(__name__)
 class MarstekUserModeSelect(SelectEntity):
     """SelectEntity to manage the user work mode of the Marstek Venus battery."""
 
-    def __init__(self, coordinator: MarstekCoordinator):
+    def __init__(self, coordinator: MarstekCoordinator, definition: dict):
         """
         Initialize the select entity with the coordinator and set attributes.
         This includes the name, unique ID, options, and mapping for the work modes.
         """
         self.coordinator = coordinator
-        self.definition = SELECT_DEFINITIONS[0]
+        self.definition = definition
         self._attr_name = f"{self.definition['name']}"
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{self.definition['key']}"
         self._attr_has_entity_name = True
@@ -80,4 +80,5 @@ class MarstekUserModeSelect(SelectEntity):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
     """Set up the MarstekUserModeSelect entity using the provided config entry."""
     coordinator = MarstekCoordinator(hass, entry)
-    async_add_entities([MarstekUserModeSelect(coordinator)])
+    entities = [MarstekUserModeSelect(coordinator, definition) for definition in SELECT_DEFINITIONS]
+    async_add_entities(entities)

--- a/custom_components/marstek_modbus/select.py
+++ b/custom_components/marstek_modbus/select.py
@@ -1,6 +1,6 @@
 """
-This module defines a SelectEntity for setting and reading the user work mode
-of a Marstek Venus battery via Modbus register 43000.
+This module defines a SelectEntity for setting and reading the user work mode, 
+force mode of a Marstek Venus battery via Modbus.
 """
 
 # Import necessary components and modules

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -11,7 +11,7 @@
       }
     },
     "error": {
-      "permission_denied": "Toegang geweigerd, ge",
+      "permission_denied": "Toegang geweigerd",
       "connection_refused": "Verbinding geweigerd door het apparaat",
       "timed_out": "Verbindingstijd verstreken",
       "invalid_host": "Ongeldig IP-adres of hostnaam",


### PR DESCRIPTION
## [2025.6.3] - 2025-07-08

### Added
- Entities now correctly register under a device in Home Assistant
<!-- - Button entity for reset functionality (Modbus write to 41000) -->
- Select entity replaces Force Charge/Discharge Mode switches (42010)
- Improved error handling with specific Modbus connection error messages
- Universal handling of Modbus types (uint16, int32, char)
- All entity types now support `enabled_by_default` flag

### Fixed
- TypeError when writing to registers (fixed incorrect `register=` argument)
- Translation loading and fallback for config flow error messages