### PR TITLE
2025.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
+## [2025.6.4] - 2025-07-10
+
+### Added
+- New fault sensor combining grid fault bits from register 36100
+- Grid Status sensor with decoded standard options from register 44100
+- Support for `scan_interval` per sensor in `SENSOR_DEFINITIONS`
+- Support for Modbus connection `timeout` and `message_wait_milliseconds` 
+- Background polling for data needed by derived sensors (e.g. SOC, Energy)
+- New efficiency sensors: Round-Trip Efficiency (monthly, total) and Stored Energy, calculated from other register values
+
+### Changed
+- Improved polling interval resolution using fastest required scan rate
+
 ## [2025.6.3] - 2025-07-08
 
 ### Added
 - Entities now correctly register under a device in Home Assistant
-<!-- - Button entity for reset functionality (Modbus write to 41000) -->
 - Select entity replaces Force Charge/Discharge Mode switches (42010)
 - Improved error handling with specific Modbus connection error messages
 - Universal handling of Modbus types (uint16, int32, char)

--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ This is a custom HACS-compatible integration for the Marstek Venus E home batter
 ### 🔧 Features
 
 - Native Modbus TCP polling via `pymodbus`
-<!-- - Automatically uses device name as entity name (if available) -->
 - Sensors for voltage, current, SOC, power, energy, and alarm status (combined bits)
 - Switches for force charge/discharge control
 - Adjustable charge/discharge power (0–2500W)
 - Entities grouped under a device in Home Assistant
 - Select entity support for multi-state control (e.g., force mode)
-<!-- - Button entity for one-time reset commands -->
+- Select entity for control modes (e.g., force mode, grid standard)
 - Some advanced sensors disabled by default for cleaner UI
-<!-- - Poll interval configurable via the UI -->
-<!-- - Icon support in Home Assistant UI -->
+- Efficient background polling with per-sensor scan intervals
+- Some advanced sensors are disabled by default to keep the UI clean
 - UI-based configuration (Config Flow)
 - Fully local, no cloud required
 
@@ -43,16 +42,15 @@ Dit is een aangepaste HACS-integratie voor de Marstek Venus E thuisbatterij via 
 ### 🔧 Functies
 
 - Communicatie via Modbus TCP met `pymodbus`
-<!-- - Automatisch gebruik van apparaatsnaam als entiteitnaam (indien beschikbaar) -->
 - Sensordata: spanning, stroom, SOC, vermogen, energie en gecombineerde alarmstatus (bits)
 - Schakelaars voor geforceerd laden/ontladen
 - Instelbare laad- en ontlaadvermogens (0–2500W)
 - Entiteiten gegroepeerd onder één apparaat in Home Assistant
 - Ondersteuning voor Select-entity (meerdere standen zoals 'force mode')
-<!-- - Resetknop via een Button-entiteit -->
+- Select-entity voor bedieningsmodi (zoals force mode en netstandaard)
 - Geavanceerde sensoren standaard uitgeschakeld voor overzicht
-<!-- - Poll-interval instelbaar via gebruikersinterface -->
-<!-- - Ondersteuning voor iconen in de Home Assistant-interface -->
+- Efficiënt achtergrond-pollen met per-sensor scan-intervallen
+- Geavanceerde sensoren zijn standaard uitgeschakeld voor een overzichtelijke interface
 - Configuratie via gebruikersinterface (config flow)
 - Volledig lokaal – geen cloudverbinding nodig
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,23 @@
 # TODO List
 
-- [x] Update documentation
-- [ ] Update poll interval via GUI
-- [x] Fix for int32/char handling 
-- [x] Use device_name as device name in Home Assistant
+
 - [ ] Fix icon display in HACS
 - [ ] Improve HACS documentation and visibility
-- [ ] Add all relevant Modbus sensors with `enabled_by_default: false`
-- [ ] Enable only key sensors (e.g. voltage, SOC, current, mode) by default
 - [ ] Provide a Lovelace dashboard example in the integration folder
+- [ ] fix reset button
+- [ ] Implement bulk reading of grouped registers to improve polling efficiency
+- [ ] Add dynamic polling interval adjustments per sensor group
+- [ ] Refactor sensor update logic to handle bulk register reads
+- [ ] Improve error handling and retry logic for Modbus communication
+- [ ] Add support for user-configurable message wait time and timeout in UI
+- [ ] Provide Lovelace dashboard example with key sensors and controls
+- [ ] Add tests for new sensor types and bit flag decoding logic
+- [x] Enable only key sensors (e.g. voltage, SOC, current, mode) by default
+- [x] add fault / alarm sensor
+- [x] add Round-Trip Efficiency
+- [x] poll interval for single sensor
+- [x] add sensors
+- [x] Add all relevant Modbus sensors with `enabled_by_default: false`
+- [x] Fix for int32/char handling 
+- [x] Use device_name as device name in Home Assistant
+- [x] Update documentation

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -398,26 +398,47 @@ SENSOR_DEFINITIONS = [
         "scan_interval": "scan_interval.state"
     },    
     {
-        # Grid fault status bits indicating various grid issues
-        "name": "Grid Status",
+        "name": "Fault Status",
         "register": 36100,
-        "count": 1,
+        "count": 2,
         "data_type": "uint16",
-        "unit": None,
-        "key": "grid_status",
-        "enabled_by_default": True,
-        "precision": 0,
+        "key": "fault_status",
+        "enabled_by_default": False,
+        "background_read": True,
         "scan_interval": "scan_interval.state",
         "bit_descriptions": {
+            # Register 36100 (bits 0-15)
             0: "Grid Overvoltage",
             1: "Grid Undervoltage",
             2: "Grid Overfrequency",
             3: "Grid Underfrequency",
             4: "Grid Peak Voltage",
             5: "Current Dcover",
-            6: "Voltage Dcover"
+            6: "Voltage Dcover",
+            # Register 36101 (bits 16-31)
+            16: "BAT Overvoltage",
+            17: "BAT Undervoltage",
+            18: "BAT Overcurrent",
+            19: "BAT low SOC",
+            20: "BAT communication failure",
+            21: "BMS protect",
+            # 48: "Hardware Bus overvoltage",
+            # 49: "Hardware Output overcurrent",
+            # 50: "Hardware trans overcurrent",
+            # 51: "Hardware battery overcurrent",
+            # 52: "Hardware Protecion",
+            # 53: "Output Overcurrent",
+            # 54: "High Voltage bus overvoltage",
+            # 55: "High Voltage bus undervoltage",
+            # 56: "Overpower Protection",
+            # 57: "FSM abnormal",
+            # 58: "Overtemperature Protection",
+            # 59: "Inverter soft start timeout",
+            # 64: "self-checking failure",
+            # 65: "eeprom failure",
+            # 66: "other system failure"
         }
-    },    
+    },
     {
         # Alarm status bits indicating various device alarms
         "name": "Alarm Status",

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -59,7 +59,20 @@ SENSOR_DEFINITIONS = [
         "enabled_by_default": True,
         "data_type": "uint16",
         "precision": 1
-    },    
+    },
+    {
+        # Total stored battery energy in kilowatt-hours
+        "name": "Battery Total Energy",
+        "register": 32105,
+        "scale": 0.001,
+        "unit": "kWh",
+        "device_class": "energy",
+        "state_class": "measurement",
+        "key": "battery_total_energy",
+        "enabled_by_default": False,
+        "data_type": "uint16",
+        "precision": 3
+    },
     {
         # Battery voltage in volts
         "name": "Battery Voltage",
@@ -101,15 +114,41 @@ SENSOR_DEFINITIONS = [
         "precision": 1
     },
     {
-        # Battery temperature in degrees Celsius
-        "name": "Battery Temperature",
+        # Internal temperature in degrees Celsius
+        "name": "Internal Temperature",
         "register": 35000,
         "scale": 0.1,
         "unit": "°C",
         "device_class": "temperature",
         "state_class": "measurement",
-        "key": "battery_temperature",
+        "key": "internal_temperature",
         "enabled_by_default": True,
+        "data_type": "int16",
+        "precision": 2
+    },
+    {
+        # Internal MOS 1 temperature in degrees Celsius
+        "name": "Internal MOS1 Temperature",
+        "register": 35001,
+        "scale": 0.1,
+        "unit": "°C",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "key": "internal_mos1_temperature",
+        "enabled_by_default": False,
+        "data_type": "int16",
+        "precision": 2
+    },
+    {
+        # Internal MOS 2 temperature in degrees Celsius
+        "name": "Internal MOS2 Temperature",
+        "register": 35002,
+        "scale": 0.1,
+        "unit": "°C",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "key": "internal_mos2_temperature",
+        "enabled_by_default": False,
         "data_type": "int16",
         "precision": 2
     },
@@ -195,6 +234,88 @@ SENSOR_DEFINITIONS = [
         "precision": 2
     },    
     {
+        # Total energy charged into the battery in kilowatt-hours per day
+        "name": "Total Daily Charging Energy",
+        "register": 33004,
+        "count": 2,
+        "scale": 0.01,
+        "unit": "kWh",
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "key": "total_daily_charging_energy",
+        "enabled_by_default": False,
+        "data_type": "uint32",
+        "precision": 2
+    },
+    {
+        # Total energy discharged from the battery in kilowatt-hours
+        "name": "Total Daily Discharging Energy",
+        "register": 33006,
+        "count": 2,
+        "scale": 0.01,
+        "unit": "kWh",
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "key": "total_daily_discharging_energy",
+        "enabled_by_default": False,
+        "data_type": "int32",
+        "precision": 2
+    },   
+    {
+        # Total energy charged into the battery in kilowatt-hours per month
+        "name": "Total Monthly Charging Energy",
+        "register": 33008,
+        "count": 2,
+        "scale": 0.01,
+        "unit": "kWh",
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "key": "total_monthly_charging_energy",
+        "enabled_by_default": False,
+        "data_type": "uint32",
+        "precision": 2
+    },
+    {
+        # Total energy discharged from the battery in kilowatt-hours per month
+        "name": "Total Monthly Discharging Energy",
+        "register": 33010,
+        "count": 2,
+        "scale": 0.01,
+        "unit": "kWh",
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "key": "total_monthly_discharging_energy",
+        "enabled_by_default": False,
+        "data_type": "int32",
+        "precision": 2
+    },      
+    {
+        # Maximum cell temperature in degrees Celsius
+        "name": "Max Cell Temperature",
+        "register": 35010,
+        "scale": 0.1,
+        "unit": "°C",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "key": "max_cell_temperature",
+        "enabled_by_default": False,
+        "data_type": "int16",
+        "precision": 2
+    },
+    {
+        # Minimum cell temperature in degrees Celsius
+        "name": "Min Cell Temperature",
+        "register": 35011,
+        "scale": 0.1,
+        "unit": "°C",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "key": "min_cell_temperature",
+        "enabled_by_default": False,
+        "data_type": "int16",
+        "precision": 2
+    },
+    {
         # Current state of the inverter device
         "name": "Inverter State",
         "register": 35100,
@@ -231,6 +352,46 @@ SENSOR_DEFINITIONS = [
         "unit": None,
         "key": "modbus_address",
         "enabled_by_default": False,
+        "precision": 0
+    },
+    {
+        # AC Offgrid Voltage in volts
+        "name": "AC Offgrid Voltage",
+        "register": 32300,
+        "scale": 0.1,
+        "unit": "V",
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "key": "ac_offgrid_voltage",
+        "enabled_by_default": False,
+        "data_type": "uint16",
+        "precision": 1
+    },
+    {
+        # AC Offgrid Current in amperes
+        "name": "AC Offgrid Current",
+        "register": 32301,
+        "scale": 0.01,
+        "unit": "A",
+        "device_class": "current",
+        "state_class": "measurement",
+        "key": "ac_offgrid_current",
+        "enabled_by_default": False,
+        "data_type": "uint16",
+        "precision": 1
+    },
+    {
+        # AC Offgrid Power in watts
+        "name": "AC Offgrid Power",
+        "register": 32302,
+        "count": 2,
+        "scale": 1,
+        "unit": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "key": "ac_offgrid_power",
+        "enabled_by_default": False,
+        "data_type": "int32",
         "precision": 0
     }
 ]

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -407,19 +407,43 @@ SENSOR_DEFINITIONS = [
         "key": "grid_status",
         "enabled_by_default": True,
         "precision": 0,
-        "scan_interval": "scan_interval.state"
+        "scan_interval": "scan_interval.state",
+        "bit_descriptions": {
+            0: "Grid Overvoltage",
+            1: "Grid Undervoltage",
+            2: "Grid Overfrequency",
+            3: "Grid Underfrequency",
+            4: "Grid Peak Voltage",
+            5: "Current Dcover",
+            6: "Voltage Dcover"
+        }
     },    
     {
         # Alarm status bits indicating various device alarms
         "name": "Alarm Status",
-        "register": 36001,
-        "count": 1,
+        "register": 36000,
+        "count": 2,
         "data_type": "uint16",
         "key": "alarm_status",
         "enabled_by_default": True,
         "unit": None,
         "precision": 0,
-        "scan_interval": "scan_interval.state"
+        "scan_interval": "scan_interval.state",
+        "bit_descriptions": {
+            # Register 36000 (bits 0-15)
+            0: "PLL Abnormal Restart",
+            1: "Overtemperature Limit",
+            2: "Low Temperature Limit",
+            3: "Fan Abnormal Warning",
+            4: "Low Battery SOC Warning",
+            5: "Output Overcurrent Warning",
+            6: "Abnormal Line Sequence Detection",
+            # Register 36001 (bits 16-31)
+            16: "WiFi Abnormal",
+            17: "BLE Abnormal",
+            18: "Network Abnormal",
+            19: "CT Connection Abnormal",
+        }
     },
     {
         # Modbus address (slave ID)

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -8,11 +8,24 @@ MODEL = "Venus E"
 # Default network configuration for Modbus connection
 DEFAULT_PORT = 502
 
+
 # Time interval (in seconds) between data scans
-SCAN_INTERVAL = 10
+# SCAN_INTERVAL = 10
+
+# Default polling intervals (seconds) per sensor category.
+# These values can be overridden via modbus.yaml using the
+# corresponding keys in each sensor's "scan_interval".
+SCAN_INTERVAL = {
+    "power": 10,         # high‑frequency power readings
+    "electrical": 30,    # voltage, current, frequency
+    "energy": 60,        # cumulative kWh counters
+    "soc": 30,           # state‑of‑charge
+    "state": 5           # fast‑changing state / alarm bits
+}
 
 # Definitions for sensors to be read from the Modbus device
-# Each sensor includes metadata for proper interpretation and display
+# Each sensor includes metadata for proper interpretation and display.
+# The "scan_interval" refers to keys inside SCAN_INTERVALS by default.
 SENSOR_DEFINITIONS = [
     {
         # Device name, stored as a string in multiple registers
@@ -58,7 +71,9 @@ SENSOR_DEFINITIONS = [
         "key": "battery_soc",
         "enabled_by_default": True,
         "data_type": "uint16",
-        "precision": 1
+        "precision": 1,
+        "background_read": True,
+        "scan_interval": "scan_interval.soc"
     },
     {
         # Total stored battery energy in kilowatt-hours
@@ -71,7 +86,9 @@ SENSOR_DEFINITIONS = [
         "key": "battery_total_energy",
         "enabled_by_default": False,
         "data_type": "uint16",
-        "precision": 3
+        "precision": 3,
+        "background_read": True,
+        "scan_interval": "scan_interval.energy"
     },
     {
         # Battery voltage in volts
@@ -84,7 +101,8 @@ SENSOR_DEFINITIONS = [
         "key": "battery_voltage",
         "enabled_by_default": True,
         "data_type": "uint16",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # Battery current in amperes
@@ -97,7 +115,8 @@ SENSOR_DEFINITIONS = [
         "key": "battery_current",
         "enabled_by_default": True,
         "data_type": "int16",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # Battery power in watts
@@ -111,7 +130,8 @@ SENSOR_DEFINITIONS = [
         "key": "battery_power",
         "enabled_by_default": True,
         "data_type": "int32",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.power"
     },
     {
         # Internal temperature in degrees Celsius
@@ -124,7 +144,8 @@ SENSOR_DEFINITIONS = [
         "key": "internal_temperature",
         "enabled_by_default": True,
         "data_type": "int16",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.temperature"        
     },
     {
         # Internal MOS 1 temperature in degrees Celsius
@@ -137,7 +158,8 @@ SENSOR_DEFINITIONS = [
         "key": "internal_mos1_temperature",
         "enabled_by_default": False,
         "data_type": "int16",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.temperature"          
     },
     {
         # Internal MOS 2 temperature in degrees Celsius
@@ -150,7 +172,8 @@ SENSOR_DEFINITIONS = [
         "key": "internal_mos2_temperature",
         "enabled_by_default": False,
         "data_type": "int16",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.temperature"
     },
     {
         # Battery AC voltage in volts
@@ -163,7 +186,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_voltage",
         "enabled_by_default": True,
         "data_type": "uint16",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # Battery AC current in amperes
@@ -176,7 +200,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_current",
         "enabled_by_default": True,
         "data_type": "int16",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # Battery AC power in watts
@@ -190,7 +215,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_power",
         "enabled_by_default": True,
         "data_type": "int32",
-        "precision": 0
+        "precision": 0,
+        "scan_interval": "scan_interval.power"
     },
     {
         # Battery AC frequency in hertz
@@ -203,7 +229,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_frequency",
         "enabled_by_default": True,
         "data_type": "int16",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # Total energy charged into the battery in kilowatt-hours
@@ -217,7 +244,9 @@ SENSOR_DEFINITIONS = [
         "key": "total_charging_energy",
         "enabled_by_default": True,
         "data_type": "uint32",
-        "precision": 2
+        "precision": 2,
+        "background_read": True,
+        "scan_interval": "scan_interval.energy"
     },
     {
         # Total energy discharged from the battery in kilowatt-hours
@@ -231,7 +260,9 @@ SENSOR_DEFINITIONS = [
         "key": "total_discharging_energy",
         "enabled_by_default": True,
         "data_type": "int32",
-        "precision": 2
+        "precision": 2,
+        "background_read": True,
+        "scan_interval": "scan_interval.energy"
     },    
     {
         # Total energy charged into the battery in kilowatt-hours per day
@@ -245,10 +276,11 @@ SENSOR_DEFINITIONS = [
         "key": "total_daily_charging_energy",
         "enabled_by_default": False,
         "data_type": "uint32",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.energy"
     },
     {
-        # Total energy discharged from the battery in kilowatt-hours
+        # Total energy discharged from the battery in kilowatt-hours per day
         "name": "Total Daily Discharging Energy",
         "register": 33006,
         "count": 2,
@@ -259,7 +291,8 @@ SENSOR_DEFINITIONS = [
         "key": "total_daily_discharging_energy",
         "enabled_by_default": False,
         "data_type": "int32",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.energy"
     },   
     {
         # Total energy charged into the battery in kilowatt-hours per month
@@ -273,7 +306,9 @@ SENSOR_DEFINITIONS = [
         "key": "total_monthly_charging_energy",
         "enabled_by_default": False,
         "data_type": "uint32",
-        "precision": 2
+        "precision": 2,
+        "background_read": True,
+        "scan_interval": "scan_interval.energy"
     },
     {
         # Total energy discharged from the battery in kilowatt-hours per month
@@ -287,7 +322,9 @@ SENSOR_DEFINITIONS = [
         "key": "total_monthly_discharging_energy",
         "enabled_by_default": False,
         "data_type": "int32",
-        "precision": 2
+        "precision": 2,
+        "background_read": True,
+        "scan_interval": "scan_interval.energy"
     },      
     {
         # Maximum cell temperature in degrees Celsius
@@ -300,7 +337,8 @@ SENSOR_DEFINITIONS = [
         "key": "max_cell_temperature",
         "enabled_by_default": False,
         "data_type": "int16",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.temperature"
     },
     {
         # Minimum cell temperature in degrees Celsius
@@ -313,7 +351,8 @@ SENSOR_DEFINITIONS = [
         "key": "min_cell_temperature",
         "enabled_by_default": False,
         "data_type": "int16",
-        "precision": 2
+        "precision": 2,
+        "scan_interval": "scan_interval.temperature"
     },
     {
         # Current state of the inverter device
@@ -332,9 +371,46 @@ SENSOR_DEFINITIONS = [
             3: "Discharge",
             4: "Backup Mode",
             5: "OTA Upgrade"
-        }
+        },
+        "scan_interval": "scan_interval.state"
     },
     {
+        # Selectable grid standard (country / regulation profile)
+        "name": "Grid Standard",
+        "register": 44100,
+        "key": "grid_standard",
+        "unit": None,
+        "scale": 1,
+        "data_type": "uint16",
+        "enabled_by_default": True,
+        "states": {
+            0: "Auto (220-240 V, 50/60 Hz)",
+            1: "EN50549",
+            2: "NL - Netherlands",
+            3: "DE - Germany",
+            4: "AT - Austria",
+            5: "UK - United Kingdom",
+            6: "ES - Spain",
+            7: "PL - Poland",
+            8: "IT - Italy",
+            9: "CN - China"
+        },
+        "scan_interval": "scan_interval.state"
+    },    
+    {
+        # Grid fault status bits indicating various grid issues
+        "name": "Grid Status",
+        "register": 36100,
+        "count": 1,
+        "data_type": "uint16",
+        "unit": None,
+        "key": "grid_status",
+        "enabled_by_default": True,
+        "precision": 0,
+        "scan_interval": "scan_interval.state"
+    },    
+    {
+        # Alarm status bits indicating various device alarms
         "name": "Alarm Status",
         "register": 36001,
         "count": 1,
@@ -342,7 +418,8 @@ SENSOR_DEFINITIONS = [
         "key": "alarm_status",
         "enabled_by_default": True,
         "unit": None,
-        "precision": 0
+        "precision": 0,
+        "scan_interval": "scan_interval.state"
     },
     {
         # Modbus address (slave ID)
@@ -365,7 +442,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_offgrid_voltage",
         "enabled_by_default": False,
         "data_type": "uint16",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # AC Offgrid Current in amperes
@@ -378,7 +456,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_offgrid_current",
         "enabled_by_default": False,
         "data_type": "uint16",
-        "precision": 1
+        "precision": 1,
+        "scan_interval": "scan_interval.electrical"
     },
     {
         # AC Offgrid Power in watts
@@ -392,7 +471,8 @@ SENSOR_DEFINITIONS = [
         "key": "ac_offgrid_power",
         "enabled_by_default": False,
         "data_type": "int32",
-        "precision": 0
+        "precision": 0,
+        "scan_interval": "scan_interval.power"
     }
 ]
 
@@ -406,6 +486,7 @@ SELECT_DEFINITIONS = [
         "key": "user_work_mode",
         "enabled_by_default": True,
         "options": ["Manual", "Anti-Feed", "Trade Mode"],
+        "scan_interval": "scan_interval.state", 
         "map_to_int": {
             "Manual": 0,
             "Anti-Feed": 1,
@@ -424,6 +505,7 @@ SELECT_DEFINITIONS = [
         "key": "force_mode",
         "enabled_by_default": False,
         "options": ["None", "Charge", "Discharge"],
+        "scan_interval": "scan_interval.state",
         "map_to_int": {
             "None": 0,
             "Charge": 1,
@@ -448,7 +530,8 @@ SWITCH_DEFINITIONS = [
         "command_off": 1,   # Disable
         "key": "backup_function",
         "enabled_by_default": True,
-        "data_type": "uint16"
+        "data_type": "uint16",
+        "scan_interval": "scan_interval.state"
     },
     {
         # RS485 communication control mode switch
@@ -457,7 +540,9 @@ SWITCH_DEFINITIONS = [
         "command_on": 21930,  # 0x55AA in decimal
         "command_off": 21947,  # 0x55BB in decimal
         "key": "rs485_control_mode",
-        "enabled_by_default": False
+        "enabled_by_default": False,
+        "scan_interval": "scan_interval.state"
+
     }    
 ]
 
@@ -514,13 +599,43 @@ NUMBER_DEFINITIONS = [
 
 # Definitions for button actions (one-time triggers)
 BUTTON_DEFINITIONS = [
+    # {
+    #     # Reset device via Modbus command
+    #     "name": "Reset Device",
+    #     "register": 41000,
+    #     "command": 21930,  # 0x55AA
+    #     "key": "reset_device",
+    #     "enabled_by_default": False,
+    #     "data_type": "uint16"
+    # }
+]
+
+# Definitions for efficiency sensors
+EFFICIENCY_SENSOR_DEFINITIONS = [
     {
-        # Reset device via Modbus command
-        "name": "Reset Device",
-        "register": 41000,
-        "command": 21930,  # 0x55AA
-        "key": "reset_device",
-        "enabled_by_default": False,
-        "data_type": "uint16"
+        "name": "Round-Trip Efficiency Total",
+        "unique_id_key": "round_trip_efficiency_total",
+        "charge_key": "total_charging_energy",
+        "discharge_key": "total_discharging_energy",
+        "soc_key": "battery_soc",
+        "max_energy_key": "battery_total_energy"
+    },
+    {
+        "name": "Round-Trip Efficiency Monthly",
+        "unique_id_key": "round_trip_efficiency_monthly",
+        "charge_key": "total_monthly_charging_energy",
+        "discharge_key": "total_monthly_discharging_energy",
+        "soc_key": "battery_soc",
+        "max_energy_key": "battery_total_energy"
+    }
+]
+
+# Definitions for stored energy sensors
+STORED_ENERGY_SENSOR_DEFINITIONS = [
+    {
+        "name": "Stored Energy",
+        "unique_id_key": "stored_energy",
+        "soc_key": "battery_soc",
+        "max_energy_key": "battery_total_energy"
     }
 ]

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -8,23 +8,61 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from .helpers.modbus_client import MarstekModbusClient
-from .const import SCAN_INTERVAL
+from .const import SCAN_INTERVAL, SENSOR_DEFINITIONS
 
 # Set up logging for debugging purposes
 import logging
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVALS_MAP = {
+    "scan_interval.power": 10,
+    "scan_interval.electrical": 30,
+    "scan_interval.energy": 60,
+    "scan_interval.soc": 30,
+    "scan_interval.state": 5,
+}
+
 class MarstekCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
+        def _get_scan_interval(value):
+            if isinstance(value, int):
+                return value
+            return SCAN_INTERVALS_MAP.get(value, 10)
+
         # Store Home Assistant instance and connection details from config entry
         self.hass = hass
         self.host = entry.data["host"]
         self.port = entry.data["port"]
-        self.interval = entry.data.get("scan_interval", SCAN_INTERVAL)
+        self.message_wait_ms = entry.data.get("message_wait_milliseconds", 35)
+        self.timeout = entry.data.get("timeout", 5)
+
+        self._poll_list = [
+            {
+                "key": s["key"],
+                "register": s["register"],
+                "count": s.get("count", 1),
+                "data_type": s["data_type"],
+                "scale": s.get("scale", 1),
+                "scan_interval": s.get("scan_interval", 10),
+                "background_read": s.get("background_read", False),
+            }
+            for s in SENSOR_DEFINITIONS
+        ]
+
+        # Determine the fastest interval among **all** sensors, ensuring all are ints
+        self.interval = min(_get_scan_interval(item["scan_interval"]) for item in self._poll_list)
 
         # Initialize and connect the Modbus client to the device
-        self.client = MarstekModbusClient(self.host, self.port)
+        self.client = MarstekModbusClient(
+            self.host,
+            self.port,
+            message_wait_ms=self.message_wait_ms,
+            timeout=self.timeout,
+        )
         self.client.connect()
+
+        # Initialize data dictionary to store background sensor values
+        self.data = {}
 
         # Initialize the DataUpdateCoordinator with update interval and logging
         super().__init__(
@@ -35,6 +73,28 @@ class MarstekCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self):
-        # This method is called periodically to refresh data.
-        # Actual register reading is performed individually by each sensor entity.
-        return True
+        """Refresh data by reading all background registers."""
+        data: dict[str, float | int | None] = {}
+
+        for sensor in self._poll_list:
+            try:
+                value = self.client.read_register(
+                    sensor["register"],
+                    sensor["data_type"],
+                    count=sensor["count"],
+                )
+                if sensor["scale"] != 1:
+                    value = round(value * sensor["scale"], 3)
+                data[sensor["key"]] = value
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.error(
+                    "Error reading register %s (%s): %s",
+                    sensor["register"],
+                    sensor["key"],
+                    err,
+                )
+                data[sensor["key"]] = None
+
+        # Store collected data in coordinator for use by sensors
+        self.data = data
+        return data

--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -17,9 +17,14 @@ class MarstekModbusClient:
     to read/write registers and interpret common data types.
     """
 
-    def __init__(self, host, port):
-        # Initialize the Modbus client with host and port
-        self.client = ModbusTcpClient(host=host, port=port)
+    def __init__(self, host, port, message_wait_ms=35, timeout=5):
+        # Initialize the Modbus client with host, port, and configurable timeouts
+        self.client = ModbusTcpClient(
+            host=host,
+            port=port,
+            timeout=timeout,  # timeout in seconds
+        )
+        self.client.message_wait_milliseconds = message_wait_ms
         self.unit_id = 1  # Default Modbus slave address (can be made configurable)
 
     def connect(self):

--- a/custom_components/marstek_modbus/manifest.json
+++ b/custom_components/marstek_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_modbus",
   "name": "Marstek Venus Modbus",
-  "version": "2025.6.3",
+  "version": "2025.6.4",
   "config_flow": true,
   "documentation": "https://github.com/viperrnmc/marstek_venus_modbus",
   "requirements": ["pymodbus>=3.5.2"],

--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from .const import SENSOR_DEFINITIONS, DOMAIN, MANUFACTURER, MODEL
+from .const import SENSOR_DEFINITIONS, DOMAIN, MANUFACTURER, MODEL, EFFICIENCY_SENSOR_DEFINITIONS, STORED_ENERGY_SENSOR_DEFINITIONS
 from .coordinator import MarstekCoordinator
 
 # Set up logging for debugging purposes
@@ -20,10 +20,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     """
     coordinator = MarstekCoordinator(hass, entry)
 
+    # Fetch the first update to ensure coordinator.data is available for sensors
+    await coordinator.async_config_entry_first_refresh()
+
     # Create a list of MarstekSensor objects, one per sensor definition
     sensors = []
     for sensor_def in SENSOR_DEFINITIONS:
         sensors.append(MarstekSensor(coordinator, sensor_def))
+
+    # Add efficiency sensors from definitions
+    for definition in EFFICIENCY_SENSOR_DEFINITIONS:
+        sensors.append(MarstekEfficiencySensor(coordinator, definition))
+
+    # Add stored energy sensors from definitions
+    for definition in STORED_ENERGY_SENSOR_DEFINITIONS:
+        sensors.append(MarstekStoredEnergySensor(coordinator, definition))
 
     # Add the sensors to Home Assistant so they become visible and usable
     async_add_entities(sensors)
@@ -73,7 +84,6 @@ class MarstekSensor(SensorEntity):
                 # Decode bits 0-3 for individual alarm flags
                 """
                 Special sensor entity for combined alarm status.
-
                 Reads a 16-bit register containing alarm bit flags, where each bit
                 indicates a different alarm condition.
 
@@ -98,6 +108,42 @@ class MarstekSensor(SensorEntity):
 
                 # Combine all active alarm labels or set state to "Normal"
                 self._state = ", ".join(alarms) if alarms else "Normal"
+
+            # Handle grid fault status sensor by decoding bit flags
+            elif self.definition.get("key") == "grid_status":
+                """
+                Special sensor entity for combined grid fault status.
+                Reads a 16‑bit register containing fault bit flags.
+
+                Bits decoded:
+                - Bit 0: Grid Overvoltage
+                - Bit 1: Grid Undervoltage
+                - Bit 2: Grid Overfrequency
+                - Bit 3: Grid Underfrequency
+                - Bit 4: Grid Peak Voltage
+                - Bit 5: Current Dcover
+                - Bit 6: Voltage Dcover
+
+                The sensor state is a comma‑separated list of active faults,
+                or "Normal" if none are active.
+                """
+                faults = []
+                if raw_value & (1 << 0):
+                    faults.append("Grid Overvoltage")
+                if raw_value & (1 << 1):
+                    faults.append("Grid Undervoltage")
+                if raw_value & (1 << 2):
+                    faults.append("Grid Overfrequency")
+                if raw_value & (1 << 3):
+                    faults.append("Grid Underfrequency")
+                if raw_value & (1 << 4):
+                    faults.append("Grid Peak Voltage")
+                if raw_value & (1 << 5):
+                    faults.append("Current Dcover")
+                if raw_value & (1 << 6):
+                    faults.append("Voltage Dcover")
+
+                self._state = ", ".join(faults) if faults else "Normal"
 
             # Handle string data types
             elif data_type == "char":
@@ -129,7 +175,8 @@ class MarstekSensor(SensorEntity):
     
     @property
     def device_info(self):
-        """Return device information to associate entities with a device in the UI.
+        """
+        Return device information to associate entities with a device in the UI.
 
         This enables the "Rename associated entities?" dialog when the user renames the integration instance.
         It also groups all entities under one device in the Home Assistant device registry.
@@ -141,3 +188,113 @@ class MarstekSensor(SensorEntity):
             "model": MODEL,
             "entry_type": "service"
         }    
+
+
+class MarstekEfficiencySensor(SensorEntity):
+    """
+    Sensor entity to calculate round-trip efficiency of the battery based on
+    total, monthly, or daily charging/discharging registers and live SOC.
+    """
+
+    def __init__(self, coordinator, definition):
+        self.coordinator = coordinator
+        self.definition = definition
+        self._attr_name = self.definition["name"]
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{self.definition['unique_id_key']}"
+        self._attr_native_unit_of_measurement = "%"
+        self._attr_device_class = "battery"
+        self._attr_state_class = "measurement"
+        self._attr_enabled_by_default = True
+        self._attr_has_entity_name = True
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
+            "name": self.coordinator.config_entry.title,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL,
+            "entry_type": "service"
+        }
+
+    @property
+    def native_value(self):
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
+        charge = data.get(self.definition["charge_key"])
+        discharge = data.get(self.definition["discharge_key"])
+        soc = data.get(self.definition["soc_key"])
+        max_energy = data.get(self.definition["max_energy_key"])
+
+        if None in (charge, discharge, soc, max_energy):
+            return None
+
+        try:
+            soc = float(soc)
+            max_energy = float(max_energy)
+            charge = float(charge)
+            discharge = float(discharge)
+            stored = soc / 100 * max_energy
+
+            if charge > 0:
+                return round(((discharge + stored) / charge) * 100, 1)
+        except (ValueError, TypeError):
+            return None
+
+        return 0
+
+    @property
+    def available(self):
+        return isinstance(self.coordinator.data, dict)
+
+class MarstekStoredEnergySensor(SensorEntity):
+    """
+    Sensor entity to calculate current stored energy based on SOC and max battery energy.
+    """
+
+    def __init__(self, coordinator, definition):
+        self.coordinator = coordinator
+        self.definition = definition
+        self._attr_name = self.definition["name"]
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{self.definition['unique_id_key']}"
+        self._attr_native_unit_of_measurement = "kWh"
+        self._attr_device_class = "energy"
+        self._attr_state_class = "measurement"
+        self._attr_enabled_by_default = True
+        self._attr_has_entity_name = True
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
+            "name": self.coordinator.config_entry.title,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL,
+            "entry_type": "service"
+        }
+
+    @property
+    def native_value(self):
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
+        soc = data.get(self.definition["soc_key"])
+        max_energy = data.get(self.definition["max_energy_key"])
+
+        if None in (soc, max_energy):
+            return None
+        try:
+            soc = float(soc)
+            max_energy = float(max_energy)
+            return round(soc / 100 * max_energy, 2)
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def available(self):
+        return isinstance(self.coordinator.data, dict)


### PR DESCRIPTION
## [2025.6.4] - 2025-07-10

### Added
- New fault sensor combining grid fault bits from register 36100
- Grid Status sensor with decoded standard options from register 44100
- Support for `scan_interval` per sensor in `SENSOR_DEFINITIONS`
- Support for Modbus connection `timeout` and `message_wait_milliseconds` 
- Background polling for data needed by derived sensors (e.g. SOC, Energy)
- New efficiency sensors: Round-Trip Efficiency (monthly, total) and Stored Energy, calculated from other register values

### Changed
- Improved polling interval resolution using fastest required scan rate