### PR TITLE
fix scaling for Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+## [2025.9.2] - 2025-09-07
+
+### Fixed
+- Corrected scaling for `Number` entities, ensuring `min`, `max`, and current values reflect the defined scale.
+- Updated logging to include scale and unit when values are updated in Home Assistant.
+
+## [2025.9.1] - 2025-09-05
+
+### Fixed
+- Switch writing fixed and now implemented with optimistic mode to handle delayed device response.
+- Fixed PyModbus 3.x / Python 3.9 compatibility: replaced slave with device_id.
+
+## [2025.9.0] - 2025-09-03
+
+### Added
+- Dependency keys registration so required values are always fetched even if disabled in Home Assistant.
+- Polling now handled centrally via the DataUpdateCoordinator.
+- Dynamic polling intervals based on sensor definitions and dependencies.
+
+### Changed
+- Calculated sensors (Round-Trip Efficiency Total, Round-Trip Efficiency Monthly, Stored Energy) with dependency handling
+- Improved logging for dependency mapping, calculation, and skipping disabled entities.
+- Cleaned up and refactored sensor calculation logic to be reusable and PEP8 compliant.
+
+## [2025.8.1] - 2025-08-12
+
+### Added
+- New Min Cell Voltage sensor (register 35043) to monitor minimum battery cell voltage
+- New Max Cell Voltage sensor (register 36943) to monitor maximum battery cell voltage
+- New Reset Device button (register 41000) to allow resetting the battery management system via Home Assistant
+
+### Changed
+- Clean up code and improve overall code quality
+
+## [2025.8.0] - 2025-08-09
+
+### Fixed
+- WiFi strength sensor now reports correct negative dBm values
+- Corrected cell temperature reading after BMS firmware version 213
+
+## [2025.7.1] - 2025-07-18
+
+### Added
+- New WiFi status sensor (register 30300): 0 = Disconnected, 1 = Connected
+- New Cloud status sensor (register 30302): 0 = Disconnected, 1 = Connected
+- New WiFi signal strength sensor (register 30303), value in dBm
+
+## [2025.7.0] - 2025-07-17
+
+### Added
+- Fully asynchronous operation for optimal performance and responsiveness
+- Background sensor update functionality temporarily disabled (to be resolved later)
+- New `Charge to SOC` select entity  
+- New `Discharge Limit Mode` sensor
+- New 'Cutoff to SOC' number entities for charge and discharge
+
+### Fixed
+- Improved error handling for incorrect count of received bytes during Modbus communication
+- Added validation to ensure the returned Modbus register matches the requested address and expected byte length
+
+## [2025.6.4] - 2025-07-10
+
+### Added
+- New fault sensor combining grid fault bits from register 36100
+- Grid Status sensor with decoded standard options from register 44100
+- Support for `scan_interval` per sensor in `SENSOR_DEFINITIONS`
+- Support for Modbus connection `timeout` and `message_wait_milliseconds` 
+- Background polling for data needed by derived sensors (e.g. SOC, Energy)
+- New efficiency sensors: Round-Trip Efficiency (monthly, total) and Stored Energy, calculated from other register values
+
+### Changed
+- Improved polling interval resolution using fastest required scan rate
+
+## [2025.6.3] - 2025-07-08
+
+### Added
+- Entities now correctly register under a device in Home Assistant
+- Select entity replaces Force Charge/Discharge Mode switches (42010)
+- Improved error handling with specific Modbus connection error messages
+- Universal handling of Modbus types (uint16, int32, char)
+- All entity types now support `enabled_by_default` flag
+
+### Fixed
+- TypeError when writing to registers (fixed incorrect `register=` argument)
+- Translation loading and fallback for config flow error messages
+
+## [2025.6.2] - 2025-07-07
+### Added
+- `enabled_by_default: false` set for all sensors except key ones (e.g. voltage, current, SOC)
+- Example Lovelace dashboard added to the integration folder
+- Support for Modbus `int32` and `char` register types
+
+### Changed
+- Select, Number, and Switch entities now implement `async_update()` and reflect real device state
+- Improved state mapping for sensors using `states` dictionary
+
+### Fixed
+- Correct mapping of 'Trade Mode' (value 2) in select register
+- All switch and number entities now generate truly unique IDs per integration instance
+
+## [2025.6.1] - 2025-07-07
+### Added
+- Combined alarm sensor decoding multiple alarm bits into one entity
+- Support for `char` type registers with proper string decoding
+- Improved sensor state mapping with `states` dictionary
+
+### Fixed
+- Fixed sensor registration to avoid duplicate unique IDs
+- Corrected `read_register` to properly handle `int32` and `char` types
+
+## [2025.6.0] - 2025-07-06
+### Added
+- Initial release with basic sensor and switch support
+- Support for Modbus int16 and uint16 registers
+- Basic configuration and polling
+
+### Changed
+- Updated documentation and improved code structure

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -120,6 +120,11 @@ class MarstekCoordinator(DataUpdateCoordinator):
     async def async_read_value(self, sensor: dict, key: str):
         """Helper to read a single sensor value from Modbus with logging and type checking."""
         entity_type = self._entity_types.get(key, get_entity_type(sensor))
+
+         # Determine scale and unit
+        scale = self._scales.get(key, sensor.get("scale", 1))
+        unit = sensor.get("unit", "N/A")
+
         try:
             value = await self.client.async_read_register(
                 register=sensor["register"],
@@ -130,9 +135,14 @@ class MarstekCoordinator(DataUpdateCoordinator):
 
             if isinstance(value, (int, float, bool, str)):
                 _LOGGER.debug(
-                    "Updated %s '%s': register=%d, value=%s",
-                    entity_type, key, sensor["register"], value,
-                )
+                     "Updated %s '%s': register=%d, value=%s, scale=%s, unit=%s",
+                    entity_type,
+                    key,
+                    sensor["register"],
+                    value,
+                    scale,
+                    unit,
+            )   
                 return value
             else:
                 _LOGGER.warning(

--- a/custom_components/marstek_modbus/manifest.json
+++ b/custom_components/marstek_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_modbus",
   "name": "Marstek Venus Modbus",
-  "version": "2025.9.0",
+  "version": "2025.9.2",
   "config_flow": true,
   "documentation": "https://github.com/viperrnmc/marstek_venus_modbus",
   "requirements": ["pymodbus>=3.9.2"],

--- a/custom_components/marstek_modbus/number.py
+++ b/custom_components/marstek_modbus/number.py
@@ -121,7 +121,8 @@ class MarstekNumber(CoordinatorEntity, NumberEntity):
         data = self.coordinator.data
         if data is None:
             return None
-        return data.get(self._key)
+        raw_value = data.get(self._key)
+        return raw_value * self._scale if raw_value is not None else None
 
     async def async_set_native_value(self, value: float) -> None:
         """
@@ -129,16 +130,16 @@ class MarstekNumber(CoordinatorEntity, NumberEntity):
         This updates the number entity in Home Assistant.
         """
         # Convert the float value to an integer for Modbus
-        value = int(value)  
+        raw_value = int(value / self._scale)
         
         # Optimistically update the coordinator data so HA shows the new state immediately
-        self.coordinator.data[self._key] = value
+        self.coordinator.data[self._key] = raw_value
         self.async_write_ha_state()
 
         # Write the value using the coordinator's async_write_value method
         await self.coordinator.async_write_value(
             register=self._register,
-            value=value,
+            value=raw_value,
             key=self._key,
             scale=self._scale,
             unit=self._unit,


### PR DESCRIPTION
### Fixed
- Corrected scaling for `Number` entities, ensuring `min`, `max`, and current values reflect the defined scale.
- Updated logging to include scale and unit when values are updated in Home Assistant.