### PR TITLE
Clossing connection and fix wrong class

### DIFF
--- a/custom_components/marstek_modbus/__init__.py
+++ b/custom_components/marstek_modbus/__init__.py
@@ -89,6 +89,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
         if unload_ok:
+            # Retrieve the coordinator and close it before removing
+            coordinator = hass.data[DOMAIN][entry.entry_id]
+            await coordinator.async_close()
             # Remove coordinator reference from hass data
             hass.data[DOMAIN].pop(entry.entry_id, None)
 

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -895,7 +895,7 @@ STORED_ENERGY_SENSOR_DEFINITIONS = [
         "key": "stored_energy",
         "unit": "kWh",
         "device_class": "energy",
-        "state_class": "measurement",
+        "state_class": "total",
         "dependency_keys": {
             "soc": "battery_soc",            
             "capacity": "battery_total_energy" 

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -411,7 +411,7 @@ SENSOR_DEFINITIONS = [
         "key": "max_cell_voltage",
         "enabled_by_default": False,
         "data_type": "int16",
-        "precision": 2,
+        "precision": 3,
         "scan_interval": "medium"
     },
     {
@@ -425,7 +425,7 @@ SENSOR_DEFINITIONS = [
         "key": "min_cell_voltage",
         "enabled_by_default": False,
         "data_type": "int16",
-        "precision": 2,
+        "precision": 3,
         "scan_interval": "medium"
     },
     {
@@ -848,7 +848,18 @@ BUTTON_DEFINITIONS = [
         "key": "reset_device",
         "enabled_by_default": False,
         "data_type": "uint16"
-    }
+    },
+    {
+        # Factory reset device via Modbus command
+        "name": "Factory reset",
+        "register": 41001,
+        "command": 21930,  # 0x55AA
+        "icon": "mdi:factory",
+        "category": "diagnostic",
+        "key": "factory_reset",
+        "enabled_by_default": False,
+        "data_type": "uint16"
+    }    
 ]
 
 # Definitions for efficiency sensors

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -279,3 +279,11 @@ class MarstekCoordinator(DataUpdateCoordinator):
         self.data.update(updated_data)
         return self.data
     
+
+    async def async_close(self):
+        """Close the Modbus client connection cleanly."""
+        try:
+            await self.client.async_close()
+            _LOGGER.debug("Closed Modbus connection to %s:%d", self.host, self.port)
+        except Exception as e:
+            _LOGGER.warning("Error closing Modbus client: %s", e)


### PR DESCRIPTION
Fixed proper closing of Modbus connections when disabling and enabling entities, preventing multiple open sessions.