### PR TITLE
Update options in force_mode register

### DIFF
--- a/custom_components/marstek_modbus/registers_v3.py
+++ b/custom_components/marstek_modbus/registers_v3.py
@@ -627,7 +627,7 @@ SELECT_DEFINITIONS = [
         "key": "force_mode",
         "enabled_by_default": False,
         "scan_interval": "high",
-        "options": {"None": 0, "Charge": 1, "Discharge": 2},
+        "options": {"Standby": 0, "None": 0, "Charge": 1, "Discharge": 2},
     },
     # {
     #     "name": "Grid Standard",


### PR DESCRIPTION
When creating an automation and setting the desired mode to be forced in a variable (e.g.: target_mode: None or target_mode: "None") there is no way to assign the **string** value 'None' to `select.marstek_venus_modbus_force_mode`. It always tries to set it as a null, which fails the automation.

Besides that: Standby is a valid option for `sensor.marstek_venus_modbus_inverter_state` so there is no translation necessary when checking if `sensor.marstek_venus_modbus_inverter_state` is the same as `select.marstek_venus_modbus_force_mode`.

This will probably create an extra option in the dropdown for Force Mode but I don't know how else to solve this. I realize this is not the best solution but I wanted to make an effort instead of just logging an issue.

How to recreate:

Create automation
```
alias: Marstek Force Mode 'None'
description: ""
triggers:
  - trigger: event
    event_type: test
    context: {}
conditions: []
actions:
  - variables:
      target_mode: None
  - target:
      entity_id: select.marstek_venus_modbus_force_mode
    data:
      option: "{{ target_mode }}"
    action: select.select_option
mode: single
```

Check the traces: 

1. In the variables step, it shows `target_mode: None` in the 'Changed variables' tab.
1. In the action step, it shows `option: null` (instead of None)

I tried the following to no avail:

* setting target_mode to None, 'None', "None", "'None'", '"None"', "\"None\"", \"None\", None | string, "{{ 'None' | string }}"...
* setting `option: "{{ target_mode | string }}"`