### PR TITLE
Add translations for `select` entities; minor formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ custom_components/marstek_modbus/icon.png
 icon*
 logo*
 TODO.md
+.venv

--- a/custom_components/marstek_modbus/registers_v3.py
+++ b/custom_components/marstek_modbus/registers_v3.py
@@ -127,10 +127,10 @@ SENSOR_DEFINITIONS = [
         "data_type": "char",
         "precision": 0,
         "scan_interval": "very_low",
-    },   
+    },
     {
         "name": "MAC Address",
-        "register": 30304, # 30402 in v12
+        "register": 30304,  # 30402 in v12
         "count": 6,
         "unit": None,
         "key": "mac_address",
@@ -141,7 +141,7 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "Battery SOC",
-        "register": 37005, # 32104 in v12
+        "register": 37005,  # 32104 in v12
         "scale": 1,
         "unit": "%",
         "device_class": "battery",
@@ -151,7 +151,7 @@ SENSOR_DEFINITIONS = [
         "data_type": "uint16",
         "precision": 1,
         "scan_interval": "medium",
-    },    
+    },
     {
         "name": "Battery Total Energy",
         "register": 32105,
@@ -167,7 +167,7 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "Battery Voltage",
-        "register": 30100, # 32100 in v12
+        "register": 30100,  # 32100 in v12
         "scale": 0.01,
         "unit": "V",
         "device_class": "voltage",
@@ -180,8 +180,8 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "Battery Current",
-        "register": 30101, # 32101 in v12
-        "scale": 0.1, # 0.01 in v12
+        "register": 30101,  # 32101 in v12
+        "scale": 0.1,  # 0.01 in v12
         "unit": "A",
         "device_class": "current",
         "state_class": "measurement",
@@ -193,7 +193,7 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "Battery Power",
-        "register": 30001, 
+        "register": 30001,
         "count": 1,
         "scale": 1,
         "unit": "W",
@@ -220,7 +220,7 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "Internal MOS1 Temperature",
-        "register": 35001, # 30002 in v3 list
+        "register": 35001,  # 30002 in v3 list
         "scale": 0.1,
         "unit": "°C",
         "device_class": "temperature",
@@ -233,7 +233,7 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "Internal MOS2 Temperature",
-        "register": 35002, # 30003 in v3 list
+        "register": 35002,  # 30003 in v3 list
         "scale": 0.1,
         "unit": "°C",
         "device_class": "temperature",
@@ -246,7 +246,7 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "AC Voltage",
-        "register": 32200, # 30004 in v3 list
+        "register": 32200,  # 30004 in v3 list
         "scale": 0.1,
         "unit": "V",
         "device_class": "voltage",
@@ -259,8 +259,8 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "AC Current",
-        "register": 37004, #32201 
-        "scale": 0.004, #0.01
+        "register": 37004,  # 32201
+        "scale": 0.004,  # 0.01
         "unit": "A",
         "device_class": "current",
         "state_class": "measurement",
@@ -272,8 +272,8 @@ SENSOR_DEFINITIONS = [
     },
     {
         "name": "AC Power",
-        "register": 30006, # 37004
-        "count": 1, 
+        "register": 30006,  # 37004
+        "count": 1,
         "scale": 1,
         "unit": "W",
         "device_class": "power",
@@ -287,7 +287,7 @@ SENSOR_DEFINITIONS = [
     {
         "name": "AC Frequency",
         "register": 32204,
-        "scale": 0.1, #0.01
+        "scale": 0.1,  # 0.01
         "unit": "Hz",
         "device_class": "frequency",
         "state_class": "measurement",
@@ -384,7 +384,7 @@ SENSOR_DEFINITIONS = [
     {
         "name": "Max Cell Temperature",
         "register": 35010,
-        "scale": 0.1, # 1
+        "scale": 0.1,  # 1
         "unit": "°C",
         "device_class": "temperature",
         "state_class": "measurement",
@@ -397,7 +397,7 @@ SENSOR_DEFINITIONS = [
     {
         "name": "Min Cell Temperature",
         "register": 35011,
-        "scale": 0.1, # 1
+        "scale": 0.1,  # 1
         "unit": "°C",
         "device_class": "temperature",
         "state_class": "measurement",
@@ -407,7 +407,7 @@ SENSOR_DEFINITIONS = [
         "precision": 1,
         "scan_interval": "medium",
     },
-   {
+    {
         "name": "Max Cell Voltage",
         "register": 37007,
         "scale": 0.001,
@@ -661,7 +661,7 @@ SENSOR_DEFINITIONS = [
             6: "Bypass",
         },
         "scan_interval": "high",
-    },    
+    },
     # {
     #     "name": "Fault Status",
     #     "register": 36100,
@@ -742,7 +742,7 @@ SENSOR_DEFINITIONS = [
         "scan_interval": "very_low",
         "precision": 0,
     },
-   {
+    {
         "name": "AC Offgrid Voltage",
         "register": 32300,
         "scale": 0.1,
@@ -844,7 +844,8 @@ SELECT_DEFINITIONS = [
         "key": "user_work_mode",
         "enabled_by_default": True,
         "scan_interval": "high",
-        "options": {"Manual": 0, "Anti-Feed": 1, "Trade Mode": 2},
+        "translation_key": "user_work_mode",
+        "options": {"manual": 0, "anti_feed": 1, "trade_mode": 2},
     },
     {
         "name": "Force Mode",
@@ -852,7 +853,8 @@ SELECT_DEFINITIONS = [
         "key": "force_mode",
         "enabled_by_default": False,
         "scan_interval": "high",
-        "options": {"Standby": 0, "Charge": 1, "Discharge": 2},
+        "translation_key": "force_mode",
+        "options": {"standby": 0, "charge": 1, "discharge": 2},
     },
     # {
     #     "name": "Grid Standard",
@@ -1018,7 +1020,7 @@ BUTTON_DEFINITIONS = [
         "key": "factory_reset",
         "enabled_by_default": False,
         "data_type": "uint16",
-    },    
+    },
 ]
 
 # EFFICIENCY_SENSOR_DEFINITIONS
@@ -1030,7 +1032,10 @@ EFFICIENCY_SENSOR_DEFINITIONS = [
         "device_class": "battery",
         "state_class": "measurement",
         "mode": "round_trip",
-        "dependency_keys": {"charge": "total_charging_energy", "discharge": "total_discharging_energy"},
+        "dependency_keys": {
+            "charge": "total_charging_energy",
+            "discharge": "total_discharging_energy",
+        },
     },
     {
         "name": "Round-Trip Efficiency Monthly",
@@ -1039,7 +1044,10 @@ EFFICIENCY_SENSOR_DEFINITIONS = [
         "device_class": "battery",
         "state_class": "measurement",
         "mode": "round_trip",
-        "dependency_keys": {"charge": "total_monthly_charging_energy", "discharge": "total_monthly_discharging_energy"},
+        "dependency_keys": {
+            "charge": "total_monthly_charging_energy",
+            "discharge": "total_monthly_discharging_energy",
+        },
     },
     {
         "name": "Conversion Efficiency",

--- a/custom_components/marstek_modbus/select.py
+++ b/custom_components/marstek_modbus/select.py
@@ -6,15 +6,15 @@ and force mode of a Marstek Venus battery via Modbus within Home Assistant.
 import logging
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import MarstekCoordinator
 from .const import DOMAIN, MANUFACTURER, MODEL
+from .coordinator import MarstekCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,10 @@ async def async_setup_entry(
     """
     # Retrieve the coordinator instance from hass data and add entities
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    entities = [MarstekSelect(coordinator, definition) for definition in coordinator.SELECT_DEFINITIONS]
+    entities = [
+        MarstekSelect(coordinator, definition)
+        for definition in coordinator.SELECT_DEFINITIONS
+    ]
     async_add_entities(entities)
 
 
@@ -50,7 +53,9 @@ class MarstekSelect(CoordinatorEntity, SelectEntity):
     the coordinator communicating with the Modbus device.
     """
 
-    def __init__(self, coordinator: MarstekCoordinator, definition: dict[str, Any]) -> None:
+    def __init__(
+        self, coordinator: MarstekCoordinator, definition: dict[str, Any]
+    ) -> None:
         """
         Initialize the select entity.
 
@@ -62,7 +67,7 @@ class MarstekSelect(CoordinatorEntity, SelectEntity):
 
         # Store the key and definition
         self._key = definition["key"]
-        self.definition = definition   
+        self.definition = definition
 
         # Assign the entity type to the coordinator mapping
         self.coordinator._entity_types[self._key] = self.entity_type
@@ -88,6 +93,13 @@ class MarstekSelect(CoordinatorEntity, SelectEntity):
         if definition.get("enabled_by_default") is False:
             self._attr_entity_registry_enabled_default = False
 
+        # Add translation key if present
+        if "translation_key" in definition:
+            self._attr_translation_key = definition["translation_key"]
+
+        # Use option keys (lowercase, underscore) instead of display names
+        self._attr_options = list(definition["options"].keys())
+
     @property
     def entity_type(self) -> str:
         """
@@ -112,7 +124,7 @@ class MarstekSelect(CoordinatorEntity, SelectEntity):
         Returns:
             List of option strings.
         """
-        return list(self.definition.get("options", {}).keys())  
+        return list(self.definition.get("options", {}).keys())
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -35,5 +35,25 @@
                 }
             }
         }
+    },
+    "entity": {
+        "select": {
+            "user_work_mode": {
+                "name": "Modus",
+                "state": {
+                    "manual": "Manuell",
+                    "anti_feed": "Eigenverbrauch",
+                    "trade_mode": "KI-Optimierung"
+                }
+            },
+            "force_mode": {
+                "name": "Force Mode",
+                "state": {
+                    "standby": "Standby",
+                    "charge": "Laden",
+                    "discharge": "Entladen"
+                }
+            }
+        }
     }
 }

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -35,5 +35,25 @@
         }
       }
     }
+  },
+  "entity": {
+    "select": {
+      "user_work_mode": {
+        "name": "User Work Mode",
+        "state": {
+          "manual": "Manual",
+          "anti_feed": "Anti-Feed",
+          "trade_mode": "Trade Mode"
+        }
+      },
+      "force_mode": {
+        "name": "Force Mode",
+        "state": {
+          "standby": "Standby",
+          "charge": "Charge",
+          "discharge": "Discharge"
+        }
+      }
+    }
   }
 }

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -19,7 +19,7 @@
       "invalid_host": "Ongeldig IP-adres of hostnaam",
       "invalid_unit_id": "Ongeldige Modbus Unit-ID (moet 1-255 zijn)",
       "unit_id_no_response": "Geen reactie van Unit-ID. Controleer of het apparaat deze Unit-ID gebruikt",
-      "cannot_connect": "Kan geen verbinding maken"     
+      "cannot_connect": "Kan geen verbinding maken"
     },
     "abort": {
       "already_configured": "Dit apparaat is al geconfigureerd"
@@ -32,6 +32,26 @@
         "description": "Pas de pollingfrequentie per categorie aan",
         "data": {
           "unit_id": "Modbus Unit-ID"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "user_work_mode": {
+        "name": "User Work Mode",
+        "state": {
+          "manual": "Manual",
+          "anti_feed": "Anti-Feed",
+          "trade_mode": "Trade Mode"
+        }
+      },
+      "force_mode": {
+        "name": "Force Mode",
+        "state": {
+          "standby": "Standby",
+          "charge": "Charge",
+          "discharge": "Discharge"
         }
       }
     }


### PR DESCRIPTION
I've added translations for the two select entities `user_work_mode` and `force_mode`. This is intended as a first issue, I will add more as I go along.

**The Dutch translation is still the original English text**, as I don't speak Dutch myself and didn't want to use machine translations when better options are available.

The other changes are due to the PEP8 autoformatter, which deletes unnecessary whitespace and enforces a maximum line length of 100 chars. I've also sorted imports alphabetically where required.

If the cosmetic changes are undesired, I'm more than happy to revert those.

Thanks for the great integration!