### PR TITLE
add port to duplicate entry check

### DIFF
--- a/custom_components/marstek_modbus/config_flow.py
+++ b/custom_components/marstek_modbus/config_flow.py
@@ -98,10 +98,11 @@ class MarstekConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except (socket.gaierror, TypeError):
                 errors["base"] = "invalid_host"
             else:
-                # Prevent duplicate entries for same host and unit_id
+                # Prevent duplicate entries for same host and port and unit_id
                 for entry in self._async_current_entries():
                     if (
                         entry.data.get(CONF_HOST) == host
+                        and entry.data.get(CONF_PORT) == port
                         and entry.data.get(CONF_UNIT_ID) == unit_id
                     ):
                         return self.async_abort(reason="already_configured")
@@ -145,7 +146,7 @@ class MarstekConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders=description_placeholders,
         )
-    
+
     async def async_step_reauth(self, data=None):
         """Re-authentication step for missing device_version."""
         errors = {}


### PR DESCRIPTION
I have multiple marstek batteries exposed on the same host but different port. (I use a modbus proxy because I have multiple modbus clients). Currently this is rejected by the integration because it only compares the host and not the port.

Not sure if that's the only relevant place. 