### PR TITLE
Change max value for registers in a.yaml

### DIFF
--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -720,7 +720,7 @@ NUMBER_DEFINITIONS:
         enabled_by_default: false
         icon: "mdi:battery-arrow-up-outline"
         min: 0
-        max: 2500
+        max: 1200
         step: 50
         unit: W
         data_type: uint16
@@ -730,7 +730,7 @@ NUMBER_DEFINITIONS:
         enabled_by_default: false
         icon: "mdi:battery-arrow-down-outline"
         min: 0
-        max: 2500
+        max: 1200
         step: 50
         unit: W
         data_type: uint16
@@ -740,7 +740,7 @@ NUMBER_DEFINITIONS:
         enabled_by_default: false
         icon: "mdi:battery-arrow-up-outline"
         min: 0
-        max: 2500
+        max: 1200
         step: 50
         unit: W
         data_type: uint16
@@ -750,7 +750,7 @@ NUMBER_DEFINITIONS:
         enabled_by_default: false
         icon: "mdi:battery-arrow-down-outline"
         min: 0
-        max: 2500
+        max: 1200
         step: 50
         unit: W
         data_type: uint16


### PR DESCRIPTION
Updated the maximum value for several registers from 2500 to 1200. The Venus A only has 1200W.