### PR TITLE
Fix indentation in a.yaml options section

### DIFF
--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -699,7 +699,7 @@ SELECT_DEFINITIONS:
         enabled_by_default: false
         scan_interval: high
         options:
-            standby: 0
+            stop: 0
             charge: 1
             discharge: 2
     schedule_1_days:

--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -691,17 +691,17 @@ SELECT_DEFINITIONS:
         enabled_by_default: true
         scan_interval: high
         options:
-        manual: 0
-        anti_feed: 1
-        trade_mode: 2
+            manual: 0
+            anti_feed: 1
+            trade_mode: 2
     force_mode:
         register: 42010
         enabled_by_default: false
         scan_interval: high
         options:
-        stop: 0
-        charge: 1
-        discharge: 2
+            standby: 0
+            charge: 1
+            discharge: 2
     schedule_1_days:
         register: 43100
         enabled_by_default: false


### PR DESCRIPTION
There was an indentation error preventing the entities from being created in HA. After fixing it manually in my HA instance the entities were created and the Marstek Venus A can now be controlled again via force mode with e.g. a Zero-Feed-In Blueprint. 