### PR TITLE
refactor: remove unit field from battery cycle sensors and update translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Below is a per-key table showing descriptive fields and the register defined in 
 | total_daily_discharging_energy    | Total daily discharging energy             | int32   | 4    | 0.01   | kWh  | 33006 | 33006 | 33006 | 33006 |
 | total_monthly_charging_energy     | Total monthly charging energy              | uint32  | 4    | 0.01   | kWh  | 33008 | 33008 | 33008 | 33008 |
 | total_monthly_discharging_energy  | Total monthly discharging energy           | int32   | 4    | 0.01   | kWh  | 33010 | 33010 | 33010 | 33010 |
-| battery_cycle_count               | Native cycle counter                       | uint16  | 2    | 1      | cycles | 34003 | 34003 |       | 34003 |
+| battery_cycle_count               | Native cycle counter                       | uint16  | 2    | 1      | -    | 34003 | 34003 |       | 34003 |
 | ac_voltage                        | AC voltage                                 | uint16  | 2    | 0.1    | V    | 32200 | 32200 | 32200 | 32200 |
 | ac_current                        | AC current                                 | int16   | 2    | 0.004/0.01| A  | 37004 | 37004 | 32201 | 37004 |
 | ac_power                          | AC power                                   | int16/32| 2/4  | 1      | W    | 30006 | 30006 | 32202 | 30006 |
@@ -209,7 +209,7 @@ Below is a per-key table showing descriptive fields and the register defined in 
 | round_trip_efficiency_monthly     | Round-trip efficiency (monthly charge/discharge) | calculated | - | - | % |  |  |  |  |
 | conversion_efficiency             | Conversion efficiency (battery ↔ AC)       | calculated | - | - | % |  |  |  |  |
 | stored_energy                     | Stored battery energy (SOC × capacity)     | calculated | - | - | kWh |  |  |  |  |
-| battery_cycle_count_calc          | Cycle count calculated from total discharge and capacity | calculated | - | - | cycles |  |  |  |  |
+| battery_cycle_count_calc          | Cycle count calculated from total discharge and capacity | calculated | - | - | - |  |  |  |  |
 
 _Notes:_
 - Columns `a`, `d`, `e_v12` and `e_v3` correspond to the YAML files under `custom_components/marstek_modbus/registers/`.

--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -282,7 +282,6 @@ SENSOR_DEFINITIONS:
     battery_cycle_count:
         register: 34003
         scale: 1
-        unit: cycles
         icon: "mdi:counter"
         state_class: total_increasing
         category: diagnostic
@@ -1349,7 +1348,7 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: medium
-        
+
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:
         register: 30300
@@ -1847,7 +1846,6 @@ STORED_ENERGY_SENSOR_DEFINITIONS:
 CYCLE_SENSOR_DEFINITIONS:
     battery_cycle_count_calc:
         key: battery_cycle_count_calc
-        unit: cycles
         icon: "mdi:counter"
         category: diagnostic
         state_class: measurement

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -228,7 +228,6 @@ SENSOR_DEFINITIONS:
     battery_cycle_count:
         register: 34003
         scale: 1
-        unit: cycles
         icon: "mdi:counter"
         state_class: total_increasing
         category: diagnostic
@@ -1173,7 +1172,6 @@ STORED_ENERGY_SENSOR_DEFINITIONS:
 CYCLE_SENSOR_DEFINITIONS:
     battery_cycle_count_calc:
         key: battery_cycle_count_calc
-        unit: cycles
         icon: "mdi:counter"
         category: diagnostic
         state_class: measurement

--- a/custom_components/marstek_modbus/registers/e_v12.yaml
+++ b/custom_components/marstek_modbus/registers/e_v12.yaml
@@ -648,7 +648,6 @@ SWITCH_DEFINITIONS:
         category: config
         scan_interval: very_low
 
-
 NUMBER_DEFINITIONS:
     set_charge_power:
         register: 42020
@@ -982,7 +981,6 @@ STORED_ENERGY_SENSOR_DEFINITIONS:
 CYCLE_SENSOR_DEFINITIONS:
     battery_cycle_count_calc:
         key: battery_cycle_count_calc
-        unit: cycles
         icon: "mdi:counter"
         category: diagnostic
         state_class: measurement

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -222,7 +222,6 @@ SENSOR_DEFINITIONS:
     battery_cycle_count:
         register: 34003
         scale: 1
-        unit: cycles
         icon: "mdi:counter"
         state_class: total_increasing
         category: diagnostic
@@ -549,7 +548,7 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: medium
-        
+
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:
         register: 30300
@@ -1047,7 +1046,6 @@ STORED_ENERGY_SENSOR_DEFINITIONS:
 CYCLE_SENSOR_DEFINITIONS:
     battery_cycle_count_calc:
         key: battery_cycle_count_calc
-        unit: cycles
         icon: "mdi:counter"
         category: diagnostic
         state_class: measurement

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -147,10 +147,10 @@
         "name": "Gesamte Entladeenergie"
       },
       "battery_cycle_count": {
-        "name": "Zyklen"
+        "name": "Vollzyklen (BMS)"
       },
       "battery_cycle_count_calc": {
-        "name": "Zyklen (Calc)"
+        "name": "Vollzyklen (berechnet)"
       },
       "total_daily_charging_energy": {
         "name": "Tägliche Ladeenergie"

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -150,10 +150,10 @@
         "name": "Total Discharging Energy"
       },
       "battery_cycle_count": {
-        "name": "Cycle Count"
+        "name": "Full Cycles (BMS)"
       },
       "battery_cycle_count_calc": {
-        "name": "Cycle Count (Calc)"
+        "name": "Full Cycles (calculated)"
       },
       "total_daily_charging_energy": {
         "name": "Daily Charging Energy"
@@ -494,7 +494,6 @@
       "mppt4_power": {
         "name": "MPPT4 Power"
       },
-
       "bluetooth_status": {
         "name": "Bluetooth Status",
         "state": {
@@ -507,17 +506,16 @@
       }
     },
     "binary_sensor": {
-      "wifi_status": { 
-        "name": "WiFi Status" 
+      "wifi_status": {
+        "name": "WiFi Status"
       },
-      "cloud_status": { 
-        "name": "Cloud Status" 
+      "cloud_status": {
+        "name": "Cloud Status"
       },
-      "discharge_limit_mode": { 
-        "name": "Discharge Limit" 
+      "discharge_limit_mode": {
+        "name": "Discharge Limit"
       }
     },
-
     "select": {
       "user_work_mode": {
         "name": "User Work Mode",
@@ -623,7 +621,6 @@
         }
       }
     },
-
     "switch": {
       "backup_function": {
         "name": "Backup Function"
@@ -690,7 +687,6 @@
       "schedule_6_start": {
         "name": "Schedule 6 Start"
       },
-
       "schedule_1_end": {
         "name": "Schedule 1 End"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -156,10 +156,10 @@
         "name": "Totale Ontlaadenergie"
       },
       "battery_cycle_count": {
-        "name": "Cycli"
+        "name": "Volledige cycli (BMS)"
       },
       "battery_cycle_count_calc": {
-        "name": "Cycli (Calc)"
+        "name": "Volledige cycli (Calc)"
       },
       "total_daily_charging_energy": {
         "name": "Dagelijkse Oplaadenergie"
@@ -437,7 +437,6 @@
       "alarm_status": {
         "name": "Alarmstatus"
       },
-
       "modbus_address": {
         "name": "Modbus-adres"
       },
@@ -453,7 +452,6 @@
       "wifi_signal_strength": {
         "name": "WiFi-signaalsterkte"
       },
-
       "round_trip_efficiency_total": {
         "name": "Totaal rendement"
       },
@@ -484,7 +482,6 @@
       "mppt2_power": {
         "name": "MPPT2 Vermogen"
       },
-
       "mppt3_voltage": {
         "name": "MPPT3 Spanning"
       },
@@ -503,7 +500,6 @@
       "mppt4_power": {
         "name": "MPPT4 Vermogen"
       },
-
       "bluetooth_status": {
         "name": "Bluetooth-status",
         "state": {
@@ -515,7 +511,6 @@
         }
       }
     },
-
     "binary_sensor": {
       "wifi_status": {
         "name": "WiFi-status"
@@ -527,7 +522,6 @@
         "name": "Ontlaadlimiet"
       }
     },
-
     "select": {
       "user_work_mode": {
         "name": "Gebruikersmodus",
@@ -560,7 +554,6 @@
           "China": "China"
         }
       },
-
       "schedule_1_days": {
         "name": "Schema 1 Dagen",
         "state": {

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -223,7 +223,7 @@
       },
       "battery_1_cell_13_voltage": {
         "name": "Batterij pack 1 Cel 13 Spanning"
-      }
+      },
       "battery_2_cell_1_voltage": {
         "name": "Batterij pack 2 Cel 1 Spanning"
       },


### PR DESCRIPTION
Remove the `unit: cycles` field from battery cycle count sensors across all register definition files (a.yaml, d.yaml, e_v12.yaml, e_v3.yaml) because cycles are not a real physical unit.

Also update translation strings in German, English, and Dutch to use more descriptive names like "Full Cycles (BMS)" and "Full Cycles (calculated)" instead of generic terms.

_Follow-up to #177_ 