### PR TITLE
chore: update hacs.json to latest requirements

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,7 +3,6 @@
   "config_flow": true,
   "domains": ["marstek_modbus"],
   "homeassistant": "2025.9.0",
-  "country": "NL",
   "render_readme": true,
   "render_hacs": true,
   "issue_tracker": "https://github.com/ViperRNMC/marstek_venus_modbus/issues",

--- a/hacs.json
+++ b/hacs.json
@@ -1,11 +1,5 @@
 {
   "name": "Marstek Venus Modbus",
-  "config_flow": true,
-  "domains": ["marstek_modbus"],
-  "homeassistant": "2025.9.0",
-  "render_readme": true,
-  "render_hacs": true,
-  "issue_tracker": "https://github.com/ViperRNMC/marstek_venus_modbus/issues",
-  "loggers": ["custom_components.marstek_modbus"],
-  "codeowners": ["@ViperRNMC"]
+  "hide_default_branch": true,
+  "homeassistant": "2025.9.0"
 }


### PR DESCRIPTION
This PR will update the `hacs.json` to the latest requirements.

see: https://www.hacs.xyz/docs/publish/start/#hacsjson

All removed fields are automatically fetched by HCAS from `manifest.json` inside the integration folder.
