### PR TITLE
feat: add virtual switch support for charge/discharge control

### DIFF
--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -59,6 +59,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
         self.BINARY_SENSOR_DEFINITIONS = []
         self.SELECT_DEFINITIONS = []
         self.SWITCH_DEFINITIONS = []
+        self.VIRTUAL_SWITCH_DEFINITIONS = []
         self.NUMBER_DEFINITIONS = []
         self.BUTTON_DEFINITIONS = []
         self.EFFICIENCY_SENSOR_DEFINITIONS = []
@@ -185,6 +186,54 @@ class MarstekCoordinator(DataUpdateCoordinator):
         
         return diagnostics
 
+    async def async_set_virtual_switch_state(self, key: str, state: bool) -> None:
+        """
+        Set the state of a virtual switch and trigger related actions.
+        
+        Args:
+            key: The key of the virtual switch
+            state: The new state of the virtual switch
+        """
+        # Set the state in data
+        self.data[key] = state
+        
+        # Trigger actions based on the switch state
+        if key == "lock_charge" and state:
+            # When lock_charge is turned on, set set_charge_power to 0
+            if "set_charge_power" in self.data:
+                self.data["set_charge_power"] = 0
+                _LOGGER.info("Lock charge activated - set_charge_power set to 0")
+        
+        if key == "lock_discharge" and state:
+            # When lock_discharge is turned on, set set_discharge_power to 0
+            if "set_discharge_power" in self.data:
+                self.data["set_discharge_power"] = 0
+                _LOGGER.info("Lock discharge activated - set_discharge_power set to 0")
+
+    def get_modified_value(self, entity_key: str, original_value: int) -> int:
+        """
+        Get the modified value to send for an entity, considering virtual switch states.
+        
+        Args:
+            entity_key: The key of the entity
+            original_value: The original value that would be sent
+            
+        Returns:
+            The modified value to actually send (e.g., 0 if blocked, original_value otherwise)
+        """
+        # Modify set_charge_power if lock_charge is active
+        if entity_key == "set_charge_power":
+            if self.data.get("lock_charge", False):
+                return 0
+        
+        # Modify set_discharge_power if lock_discharge is active
+        if entity_key == "set_discharge_power":
+            if self.data.get("lock_discharge", False):
+                return 0
+        
+        # Return original value if not modified
+        return original_value
+     
     async def async_init(self):
         """Asynchronously initialize the Modbus connection."""
         from homeassistant.util.dt import utcnow
@@ -217,6 +266,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
             self.BINARY_SENSOR_DEFINITIONS = data.get("BINARY_SENSOR_DEFINITIONS", [])
             self.SELECT_DEFINITIONS = data.get("SELECT_DEFINITIONS", [])
             self.SWITCH_DEFINITIONS = data.get("SWITCH_DEFINITIONS", [])
+            self.VIRTUAL_SWITCH_DEFINITIONS = data.get("VIRTUAL_SWITCH_DEFINITIONS", [])
             self.NUMBER_DEFINITIONS = data.get("NUMBER_DEFINITIONS", [])
             self.BUTTON_DEFINITIONS = data.get("BUTTON_DEFINITIONS", [])
             self.EFFICIENCY_SENSOR_DEFINITIONS = data.get("EFFICIENCY_SENSOR_DEFINITIONS", [])

--- a/custom_components/marstek_modbus/number.py
+++ b/custom_components/marstek_modbus/number.py
@@ -131,14 +131,21 @@ class MarstekNumber(CoordinatorEntity, NumberEntity):
         # Convert the float value to an integer for Modbus
         raw_value = int(value / self._scale)
         
+        # Get the modified value, considering virtual switch states
+        value_to_send = self.coordinator.get_modified_value(self._key, raw_value)
+        
+        # Log if value was modified
+        if value_to_send != raw_value:
+            _LOGGER.debug("Entity '%s' was modified by coordinator. Sending %d instead of %d.", self._key, value_to_send, raw_value)
+        
         # Optimistically update the coordinator data so HA shows the new state immediately
-        self.coordinator.data[self._key] = raw_value
+        self.coordinator.data[self._key] = value_to_send
         self.async_write_ha_state()
 
         # Write the value using the coordinator's async_write_value method
         success = await self.coordinator.async_write_value(
             register=self._register,
-            value=raw_value,
+            value=value_to_send,
             key=self._key,
             scale=self._scale,
             unit=self._unit,

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -735,6 +735,18 @@ SWITCH_DEFINITIONS:
         category: config
         scan_interval: very_low
 
+VIRTUAL_SWITCH_DEFINITIONS:
+    lock_charge:
+        key: lock_charge
+        enabled_by_default: true
+        icon: "mdi:lock"
+        # category: diagnostic
+    lock_discharge:
+        key: lock_discharge
+        enabled_by_default: true
+        icon: "mdi:lock"
+        # category: diagnostic
+
 NUMBER_DEFINITIONS:
     set_charge_power:
         register: 42020

--- a/custom_components/marstek_modbus/switch.py
+++ b/custom_components/marstek_modbus/switch.py
@@ -38,7 +38,14 @@ async def async_setup_entry(
     """
     # Retrieve the coordinator instance from hass data and add entities
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    
+    # Create real switch entities
     entities = [MarstekSwitch(coordinator, definition) for definition in coordinator.SWITCH_DEFINITIONS]
+    
+    # Create virtual switch entities
+    virtual_entities = [MarstekVirtualSwitch(coordinator, definition) for definition in coordinator.VIRTUAL_SWITCH_DEFINITIONS]
+    entities.extend(virtual_entities)
+    
     async_add_entities(entities)
 
 
@@ -167,6 +174,99 @@ class MarstekSwitch(CoordinatorEntity, SwitchEntity):
             unit=self.definition.get("unit"),
             entity_type=self.entity_type,
         )
+
+    @property
+    def device_info(self) -> dict:
+        """
+        Return device information for Home Assistant's device registry.
+        Includes identifiers, name, manufacturer, model, and entry type.
+        """
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
+            "name": self.coordinator.config_entry.title,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL,
+            "entry_type": "service",
+        }
+
+
+class MarstekVirtualSwitch(CoordinatorEntity, SwitchEntity):
+    """
+    Representation of a virtual switch entity for Marstek Venus.
+    
+    Virtual switches are not based on Modbus registers but are managed
+    internally by the coordinator for decision-making purposes.
+    """
+
+    def __init__(self, coordinator: MarstekCoordinator, definition: dict):
+        """
+        Initialize the virtual switch entity.
+
+        Args:
+            coordinator: The data update coordinator instance.
+            definition: Dictionary containing virtual switch configuration.
+        """
+        super().__init__(coordinator)
+
+        # Store the key and definition
+        self._key = definition["key"]
+        self.definition = definition
+
+        # Assign the entity type to the coordinator mapping
+        self.coordinator._entity_types[self._key] = self.entity_type
+
+        # Set entity attributes from definition
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{self._key}"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = self._key
+
+        # Internal state (default to False)
+        self._state = False
+
+        # Set optional attributes
+        if "category" in self.definition:
+            self._attr_entity_category = EntityCategory(self.definition.get("category"))
+        if "icon" in self.definition:
+            self._attr_icon = self.definition.get("icon")
+        if definition.get("enabled_by_default") is False:
+            self._attr_entity_registry_enabled_default = False
+
+    @property
+    def entity_type(self) -> str:
+        """
+        Return the type of this entity for logging purposes.
+        This allows the coordinator to show more descriptive messages.
+        """
+        return "virtual_switch"
+
+    @property
+    def available(self) -> bool:
+        """
+        Return True if the coordinator has successfully fetched data.
+        Used by Home Assistant to determine entity availability.
+        """
+        return self.coordinator.last_update_success
+
+    @property
+    def is_on(self) -> bool:
+        """Return the current state of the virtual switch."""
+        return self._state
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the virtual switch on."""
+        self._state = True
+        self.async_write_ha_state()
+        
+        # Notify coordinator about state change and trigger actions
+        await self.coordinator.async_set_virtual_switch_state(self._key, True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the virtual switch off."""
+        self._state = False
+        self.async_write_ha_state()
+        
+        # Notify coordinator about state change and trigger actions
+        await self.coordinator.async_set_virtual_switch_state(self._key, False)
 
     @property
     def device_info(self) -> dict:


### PR DESCRIPTION
## Overview
This PR implements virtual switches for the Marstek Modbus integration, enabling internal decision-making logic without relying on physical Modbus registers.

The idea is, to make it possible, to implement some general useful features, which needs a little bit of logic and are not direct modbus related (little bit like the calculated sensors).
In this example I added two switches which can be used to lock/unlock charging/discharging at all (fixes the charge/discharge power to 0). But maybe there are more good usecases.

@ViperRNMC is this anything you want to see inside this integration at all?

_PS.: Testing is currently ongoing._

## Changes Made

### 1. New Virtual Switch Class (`switch.py`)
- Added `MarstekVirtualSwitch` class that inherits from `CoordinatorEntity` and `SwitchEntity`
- Virtual switches are managed internally by the coordinator
- Supports optional attributes like `icon` and `category`
- Triggers coordinator actions on state changes

### 2. Coordinator Enhancements (`coordinator.py`)
- Added `VIRTUAL_SWITCH_DEFINITIONS` list to store virtual switch definitions
- Added `get_modified_value(entity_key, original_value)` method for value modification logic
- Added `async_set_virtual_switch_state(key, state)` method to set virtual switch states and trigger actions
- Virtual switches can modify values of other entities (e.g., set `set_charge_power` to 0 when `lock_charge` is active)

### 3. Number Entity Updates (`number.py`)
- Modified `async_set_native_value()` to use `coordinator.get_modified_value()` for value modification
- Values are now modified based on virtual switch states before being sent to Modbus
- `get_modified_value()` can used by other entity types as well if needed

### 4. Setup Function Updates (`switch.py`)
- Modified `async_setup_entry()` to create both real and virtual switch entities
- Virtual switches are instantiated separately and added to the entity list

## Features
- **Centralized Logic**: All modification rules are managed in the coordinator
- **Flexible**: Supports complex logic beyond simple on/off (e.g., setting values to 0)
- **Extensible**: Easy to add new virtual switches and modification rules
- **Consistent**: Applied uniformly across all entity types
- **Actionable**: Virtual switches can trigger actions when toggled

## Example Usage
```yaml
VIRTUAL_SWITCH_DEFINITIONS:
  lock_charge:
    key: lock_charge
    enabled_by_default: true
    icon: "mdi:lock"
  lock_discharge:
    key: lock_discharge
    enabled_by_default: true
    icon: "mdi:lock"
```

When `lock_charge` is activated, `set_charge_power` is automatically set to 0.

## Benefits
- Enables internal decision-making logic without physical Modbus registers
- Provides a clean separation between real and virtual switches
- Allows for complex conditional logic based on virtual switch states
- Maintains compatibility with existing Home Assistant UI


## TODO

- [ ] more Testing
- [ ] add translation strings
- [ ] refactoring if necessary

---

<details>
<summary>Infos from Commit Message</summary>

This commit introduces virtual switch functionality to the Marstek Modbus integration, allowing users to lock charge or discharge operations through software-controlled switches.

Key changes:
- Added VIRTUAL_SWITCH_DEFINITIONS to coordinator and register configuration
- Implemented async_set_virtual_switch_state() method to handle virtual switch state changes
- Added get_modified_value() method to modify power values based on virtual switch states
- Created MarstekVirtualSwitch entity class for Home Assistant integration
- Modified number.py to respect virtual switch states when writing values
- Added lock_charge and lock_discharge virtual switches to e_v3.yaml configuration

When lock_charge is enabled, set_charge_power is automatically set to 0. When lock_discharge is enabled, set_discharge_power is automatically set to 0.
</details>