### PR TITLE
fix: Rename stop option to standby in select definitions

### DIFF
--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -1383,7 +1383,7 @@ SELECT_DEFINITIONS:
         enabled_by_default: false
         scan_interval: high
         options:
-            stop: 0
+            standby: 0
             charge: 1
             discharge: 2
     schedule_1_days:

--- a/custom_components/marstek_modbus/registers/e_v12.yaml
+++ b/custom_components/marstek_modbus/registers/e_v12.yaml
@@ -481,7 +481,7 @@ SELECT_DEFINITIONS:
         enabled_by_default: false
         scan_interval: high
         options:
-            stop: 0
+            standby: 0
             charge: 1
             discharge: 2
     grid_standard:

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -583,7 +583,7 @@ SELECT_DEFINITIONS:
         enabled_by_default: false
         scan_interval: high
         options:
-            stop: 0
+            standby: 0
             charge: 1
             discharge: 2
     schedule_1_days:


### PR DESCRIPTION
This change updates the option name from "stop" to "standby" across multiple register configuration files (a.yaml, e_v12.yaml, e_v3.yaml) for the Marstek Modbus integration.

The modification affects the SELECT_DEFINITIONS section where the option value 0 is now labeled as "standby" instead of "stop", maintaining consistency with the translation files.

see e.g.:
https://github.com/ViperRNMC/marstek_venus_modbus/blob/c3026922ee0da25e9036bbdcbfbf029733a2a3c2/custom_components/marstek_modbus/translations/en.json#L542

Only the register file of the "D" was correct before:
https://github.com/ViperRNMC/marstek_venus_modbus/blob/c3026922ee0da25e9036bbdcbfbf029733a2a3c2/custom_components/marstek_modbus/registers/d.yaml#L711

This will fix the wrong translation on the UI
<img width="262" height="193" alt="image" src="https://github.com/user-attachments/assets/1c3f36d3-f4bc-4659-8aa8-35e749c48970" />


