### PR TITLE
fix(sensor): Add suggested display precision and unit properties

### DIFF
--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -177,13 +177,17 @@ class MarstekSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def suggested_display_precision(self) -> int | None:
-        """Suggest display precision based on definition."""
+        """Suggest display precision based on definition, but only for numeric values."""
+        if self.states:
+            return None
         return self.definition.get("precision")
-    
+
     @property
     def suggested_display_unit(self) -> str | None:
-        """Suggest display unit based on definition."""
-        return self.definition.get("unit")
+        """Suggest display unit based on definition, but only if not a mapped state."""
+        if self.states:
+            return None
+        return self.definition.get("unit") or self.native_unit_of_measurement
 
     @property
     def device_info(self) -> dict:

--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -183,7 +183,7 @@ class MarstekSensor(CoordinatorEntity, SensorEntity):
     @property
     def suggested_display_unit(self) -> str | None:
         """Suggest display unit based on definition."""
-        return self.definition.get("unit") or self.native_unit_of_measurement
+        return self.definition.get("unit")
 
     @property
     def device_info(self) -> dict:

--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -176,6 +176,16 @@ class MarstekSensor(CoordinatorEntity, SensorEntity):
         return value
 
     @property
+    def suggested_display_precision(self) -> int | None:
+        """Suggest display precision based on definition."""
+        return self.definition.get("precision")
+    
+    @property
+    def suggested_display_unit(self) -> str | None:
+        """Suggest display unit based on definition."""
+        return self.definition.get("unit") or self.native_unit_of_measurement
+
+    @property
     def device_info(self) -> dict:
         return {
             "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},

--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -177,17 +177,17 @@ class MarstekSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def suggested_display_precision(self) -> int | None:
-        """Suggest display precision based on definition, but only for numeric values."""
+        """Suggest display precision based on definition, but only if not a string or mapped state."""
         if self.states:
             return None
         return self.definition.get("precision")
 
     @property
     def suggested_display_unit(self) -> str | None:
-        """Suggest display unit based on definition, but only if not a mapped state."""
+        """Suggest display unit based on definition, but only if not a string or mapped state."""
         if self.states:
             return None
-        return self.definition.get("unit") or self.native_unit_of_measurement
+        return self.definition.get("unit")
 
     @property
     def device_info(self) -> dict:


### PR DESCRIPTION
This PR improves how sensor values are rendered in the Home Assistant UI, specifically addressing an issue where sensors with high precision (e.g., battery cell voltages with 3 decimal places) would lose their formatting when the value was a whole number.

**Changes**

- Added suggested_display_precision: The entity now explicitly communicates the desired precision from the sensor definition to the Home Assistant frontend. This ensures that a value of 3.0 V is correctly displayed as 3.000 V if precision: 3 is defined.

- Added suggested_display_unit: Ensures the UI uses the preferred unit from the sensor definition as the default display unit.


see also: https://developers.home-assistant.io/docs/core/entity/sensor/

This PR should fix #187 

---

<img width="336" height="178" alt="image" src="https://github.com/user-attachments/assets/f454bbf9-8415-4ac4-b489-baeebe14b126" />
