### PR TITLE
fix(registers): remove unnecessary unit and precision properties

### DIFF
--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -23,57 +23,45 @@ SENSOR_DEFINITIONS:
         register: 31000
         count: 10
         data_type: char
-        unit: null
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
         scan_interval: very_low
-        precision: 0
     bms_version:
         register: 30204
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     vms_version:
         register: 30202
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     ems_version:
         register: 30200
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        precision: 0
         scan_interval: very_low
     comm_module_firmware:
         register: 30350
         count: 6
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        precision: 0
         scan_interval: very_low
     mac_address:
         register: 30304
         count: 6
-        unit: null
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        precision: 0
         scan_interval: very_low
     battery_soc:
         register: 32104
@@ -1156,11 +1144,9 @@ SENSOR_DEFINITIONS:
     inverter_state:
         register: 35100
         scale: 1
-        unit: null
         icon: "mdi:state-machine"
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         states:
             0: Sleep
             1: Standby
@@ -1173,11 +1159,9 @@ SENSOR_DEFINITIONS:
     modbus_address:
         register: 41100
         data_type: uint16
-        unit: null
         icon: "mdi:home-automation"
         enabled_by_default: false
         scan_interval: very_low
-        precision: 0
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -1343,7 +1327,6 @@ SENSOR_DEFINITIONS:
     bluetooth_status:
         register: 30301
         data_type: uint16
-        unit: null
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
@@ -1353,7 +1336,6 @@ BINARY_SENSOR_DEFINITIONS:
     wifi_status:
         register: 30300
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:check-network-outline"
@@ -1362,7 +1344,6 @@ BINARY_SENSOR_DEFINITIONS:
     cloud_status:
         register: 30302
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:cloud-outline"

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -29,57 +29,45 @@ SENSOR_DEFINITIONS:
         register: 31000
         count: 10
         data_type: char
-        unit: null
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
         scan_interval: very_low
-        precision: 0
     bms_version:
         register: 30204
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     vms_version:
         register: 30202
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     ems_version:
         register: 30200
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        precision: 0
         scan_interval: very_low
     comm_module_firmware:
         register: 30350
         count: 6
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        precision: 0
         scan_interval: very_low
     mac_address:
         register: 30304
         count: 6
-        unit: null
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        precision: 0
         scan_interval: very_low
     battery_soc:
         register: 32104
@@ -482,11 +470,9 @@ SENSOR_DEFINITIONS:
     inverter_state:
         register: 35100
         scale: 1
-        unit: null
         icon: "mdi:state-machine"
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         states:
             0: Sleep
             1: Standby
@@ -499,11 +485,9 @@ SENSOR_DEFINITIONS:
     modbus_address:
         register: 41100
         data_type: uint16
-        unit: null
         icon: "mdi:home-automation"
         enabled_by_default: false
         scan_interval: very_low
-        precision: 0
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -669,7 +653,6 @@ SENSOR_DEFINITIONS:
     bluetooth_status:
         register: 30301
         data_type: uint16
-        unit: null
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
@@ -678,7 +661,6 @@ BINARY_SENSOR_DEFINITIONS:
     wifi_status:
         register: 30300
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:check-network-outline"
@@ -687,7 +669,6 @@ BINARY_SENSOR_DEFINITIONS:
     cloud_status:
         register: 30302
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:cloud-outline"

--- a/custom_components/marstek_modbus/registers/e_v12.yaml
+++ b/custom_components/marstek_modbus/registers/e_v12.yaml
@@ -14,66 +14,52 @@ SENSOR_DEFINITIONS:
         register: 31000
         count: 10
         data_type: char
-        unit: null
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
         scan_interval: very_low
-        precision: 0
     sn_code:
         register: 31200
         count: 10
         data_type: char
-        unit: null
         enabled_by_default: false
         scan_interval: very_low
-        precision: 0
     software_version:
         register: 31100
         scale: 0.01
-        unit: null
         icon: "mdi:ticket-confirmation-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 2
         scan_interval: very_low
     bms_version:
         register: 31102
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     ems_version:
         register: 31101
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        precision: 0
         scan_interval: very_low
     comm_module_firmware:
         register: 30800
         count: 6
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        precision: 0
         scan_interval: very_low
     mac_address:
         register: 30402
         count: 6
-        unit: null
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        precision: 0
         scan_interval: very_low
     battery_soc:
         register: 32104
@@ -306,11 +292,9 @@ SENSOR_DEFINITIONS:
     inverter_state:
         register: 35100
         scale: 1
-        unit: null
         icon: "mdi:state-machine"
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         states:
             0: Sleep
             1: Standby
@@ -366,8 +350,6 @@ SENSOR_DEFINITIONS:
         icon: "mdi:alert"
         enabled_by_default: true
         category: diagnostic
-        unit: null
-        precision: 0
         scan_interval: high
         bit_descriptions:
             0: PLL Abnormal Restart
@@ -384,11 +366,9 @@ SENSOR_DEFINITIONS:
     modbus_address:
         register: 41100
         data_type: uint16
-        unit: null
         icon: "mdi:home-automation"
         enabled_by_default: false
         scan_interval: very_low
-        precision: 0
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -434,7 +414,6 @@ SENSOR_DEFINITIONS:
     bluetooth_status:
         register: 30301
         data_type: uint16
-        unit: null
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
@@ -444,7 +423,6 @@ BINARY_SENSOR_DEFINITIONS:
     wifi_status:
         register: 30300
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:check-network-outline"
@@ -453,7 +431,6 @@ BINARY_SENSOR_DEFINITIONS:
     cloud_status:
         register: 30302
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:cloud-outline"
@@ -462,7 +439,6 @@ BINARY_SENSOR_DEFINITIONS:
     discharge_limit_mode:
         register: 41010
         data_type: uint16
-        unit: null
         icon: "mdi:battery-arrow-down-outline"
         enabled_by_default: false
         scan_interval: medium

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -23,57 +23,45 @@ SENSOR_DEFINITIONS:
         register: 31000
         count: 10
         data_type: char
-        unit: null
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
         scan_interval: very_low
-        precision: 0
     bms_version:
         register: 30204
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     vms_version:
         register: 30202
-        unit: null
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         scan_interval: very_low
     ems_version:
         register: 30200
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        precision: 0
         scan_interval: very_low
     comm_module_firmware:
         register: 30350
         count: 6
-        unit: null
         category: diagnostic
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        precision: 0
         scan_interval: very_low
     mac_address:
         register: 30304
         count: 6
-        unit: null
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        precision: 0
         scan_interval: very_low
     battery_soc:
         register: 34002
@@ -476,11 +464,9 @@ SENSOR_DEFINITIONS:
     inverter_state:
         register: 35100
         scale: 1
-        unit: null
         icon: "mdi:state-machine"
         enabled_by_default: true
         data_type: uint16
-        precision: 0
         states:
             0: Sleep
             1: Standby
@@ -493,11 +479,9 @@ SENSOR_DEFINITIONS:
     modbus_address:
         register: 41100
         data_type: uint16
-        unit: null
         icon: "mdi:home-automation"
         enabled_by_default: false
         scan_interval: very_low
-        precision: 0
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -543,7 +527,6 @@ SENSOR_DEFINITIONS:
     bluetooth_status:
         register: 30301
         data_type: uint16
-        unit: null
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
@@ -553,7 +536,6 @@ BINARY_SENSOR_DEFINITIONS:
     wifi_status:
         register: 30300
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:check-network-outline"
@@ -562,7 +544,6 @@ BINARY_SENSOR_DEFINITIONS:
     cloud_status:
         register: 30302
         data_type: uint16
-        unit: null
         category: diagnostic
         device_class: connectivity
         icon: "mdi:cloud-outline"


### PR DESCRIPTION
# HOTFIX
Current beta release is broken if any string sensor is enabled which can not be parsed as numeric value, e.g. the Device Name!

## Summary
This PR removes explicit unit: null and precision: 0 properties from sensor definitions across several register configuration files. These properties were causing a regression where sensors intended to be interpreted as strings were being misclassified as numeric sensors..

## Changes
Cleanup of Register Files: Removed redundant unit and precision definitions in:
- a.yaml
- d.yaml
- e_v12.yaml
- e_v3.yaml

Logic Alignment: Ensuring that string-based sensors do not carry numeric metadata that triggers validation errors or incorrect formatting in the UI/downstream systems.

## The Problem
In the current implementation, providing a precision: 0 value acts as a signal to HA that the sensor is a numeric type (integer). When this is applied to sensors that actually return string values (e.g., status messages, firmware versions, or serial numbers), it leads to:

Parsing Errors: The system attempts to cast a string to a number.

Display Issues: Incorrect formatting in the frontend.

Validation Failures: Metadata conflicts where a sensor cannot have both a string payload and a numeric precision.

### Context
Indirectly relates to: #190

Impact: Fixes cases where string sensors were "breaking" or showing up with invalid states because of the forced numeric metadata.