### PR TITLE
Rename MAC Address Sensor to BLE MAC Address for Venus E Gen3

### DIFF
--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -56,11 +56,12 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: char
         scan_interval: very_low
-    mac_address:
+    ble_mac_address:
         register: 30304
         count: 6
-        enabled_by_default: true
-        icon: "mdi:ethernet"
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:bluetooth"
         data_type: char
         scan_interval: very_low
     battery_soc:

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -62,11 +62,12 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: char
         scan_interval: very_low
-    mac_address:
+    ble_mac_address:
         register: 30304
         count: 6
-        enabled_by_default: true
-        icon: "mdi:ethernet"
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:bluetooth"
         data_type: char
         scan_interval: very_low
     battery_soc:

--- a/custom_components/marstek_modbus/registers/e_v12.yaml
+++ b/custom_components/marstek_modbus/registers/e_v12.yaml
@@ -54,11 +54,12 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: char
         scan_interval: very_low
-    mac_address:
+    ble_mac_address:
         register: 30402
         count: 6
-        enabled_by_default: true
-        icon: "mdi:ethernet"
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:bluetooth"
         data_type: char
         scan_interval: very_low
     battery_soc:

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -56,11 +56,12 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: char
         scan_interval: very_low
-    mac_address:
+    ble_mac_address:
         register: 30304
         count: 6
-        enabled_by_default: true
-        icon: "mdi:ethernet"
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:bluetooth"
         data_type: char
         scan_interval: very_low
     battery_soc:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -83,8 +83,8 @@
       "comm_module_firmware": {
         "name": "Kommunikationsmodul-Firmware"
       },
-      "mac_address": {
-        "name": "MAC-Adresse"
+      "ble_mac_address": {
+        "name": "Bluetooth-MAC"
       },
       "battery_soc": {
         "name": "SoC Batterie"

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -86,8 +86,8 @@
       "comm_module_firmware": {
         "name": "Communication Module Firmware"
       },
-      "mac_address": {
-        "name": "MAC Address"
+      "ble_mac_address": {
+        "name": "Bluetooth MAC"
       },
       "battery_soc": {
         "name": "Battery SoC"

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -92,8 +92,8 @@
       "comm_module_firmware": {
         "name": "Communicatiemodule Firmware"
       },
-      "mac_address": {
-        "name": "MAC-adres"
+      "ble_mac_address": {
+        "name": "Bluetooth-MAC"
       },
       "battery_soc": {
         "name": "Batterij SoC"


### PR DESCRIPTION
## Problem

Register 30304 contains the Bluetooth MAC address, not a LAN/WiFi MAC address. The previous name `mac_address` with an ethernet icon was misleading.

## Solution

- Renamed `mac_address` → `ble_mac_address` in e_v3.yaml
- Changed icon from `mdi:ethernet` to `mdi:bluetooth`
- Set `enabled_by_default: false` and `category: diagnostic` since this is rarely needed
- Updated de/en/nl translations
