### PR TITLE
Add BMS Current Limits and Calculated Power Limits for Venus E Gen3

### DIFF
--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -833,9 +833,7 @@ def get_registers(version: str):
                     "EFFICIENCY_SENSOR_DEFINITIONS": _normalize_section(
                         data.get("EFFICIENCY_SENSOR_DEFINITIONS")
                     ),
-                    "PRODUCT_SENSOR_DEFINITIONS": _normalize_section(
-                        data.get("PRODUCT_SENSOR_DEFINITIONS")
-                    ),
+                    "PRODUCT_SENSOR_DEFINITIONS": _normalize_section(data.get("PRODUCT_SENSOR_DEFINITIONS")),
                     "STORED_ENERGY_SENSOR_DEFINITIONS": _normalize_section(
                         data.get("STORED_ENERGY_SENSOR_DEFINITIONS")
                     ),

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -63,6 +63,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
         self.NUMBER_DEFINITIONS = []
         self.BUTTON_DEFINITIONS = []
         self.EFFICIENCY_SENSOR_DEFINITIONS = []
+        self.PRODUCT_SENSOR_DEFINITIONS = []
         self.STORED_ENERGY_SENSOR_DEFINITIONS = []
         self.CYCLE_SENSOR_DEFINITIONS = []
 
@@ -232,6 +233,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
             self.NUMBER_DEFINITIONS = data.get("NUMBER_DEFINITIONS", [])
             self.BUTTON_DEFINITIONS = data.get("BUTTON_DEFINITIONS", [])
             self.EFFICIENCY_SENSOR_DEFINITIONS = data.get("EFFICIENCY_SENSOR_DEFINITIONS", [])
+            self.PRODUCT_SENSOR_DEFINITIONS = data.get("PRODUCT_SENSOR_DEFINITIONS", [])
             self.STORED_ENERGY_SENSOR_DEFINITIONS = data.get("STORED_ENERGY_SENSOR_DEFINITIONS", [])
             self.CYCLE_SENSOR_DEFINITIONS = data.get("CYCLE_SENSOR_DEFINITIONS", [])
 
@@ -473,6 +475,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
         # Collect all dependency keys from all definitions
         all_definitions_for_deps = (
             self.EFFICIENCY_SENSOR_DEFINITIONS
+            + self.PRODUCT_SENSOR_DEFINITIONS
             + self.STORED_ENERGY_SENSOR_DEFINITIONS
             + self.CYCLE_SENSOR_DEFINITIONS
         )
@@ -750,6 +753,7 @@ def get_registers(version: str):
       - NUMBER_DEFINITIONS
       - BUTTON_DEFINITIONS
       - EFFICIENCY_SENSOR_DEFINITIONS
+      - PRODUCT_SENSOR_DEFINITIONS
       - STORED_ENERGY_SENSOR_DEFINITIONS
     - CYCLE_SENSOR_DEFINITIONS
 
@@ -828,6 +832,9 @@ def get_registers(version: str):
                     "BUTTON_DEFINITIONS": _normalize_section(data.get("BUTTON_DEFINITIONS")),
                     "EFFICIENCY_SENSOR_DEFINITIONS": _normalize_section(
                         data.get("EFFICIENCY_SENSOR_DEFINITIONS")
+                    ),
+                    "PRODUCT_SENSOR_DEFINITIONS": _normalize_section(
+                        data.get("PRODUCT_SENSOR_DEFINITIONS")
                     ),
                     "STORED_ENERGY_SENSOR_DEFINITIONS": _normalize_section(
                         data.get("STORED_ENERGY_SENSOR_DEFINITIONS")

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -476,6 +476,30 @@ SENSOR_DEFINITIONS:
             5: OTA Upgrade
             6: Bypass
         scan_interval: high
+    bms_charge_current_limit:
+        register: 35111
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:current-dc"
+        data_type: uint16
+        precision: 1
+        scan_interval: very_low
+    bms_discharge_current_limit:
+        register: 35112
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:current-dc"
+        data_type: uint16
+        precision: 1
+        scan_interval: very_low
     modbus_address:
         register: 41100
         data_type: uint16
@@ -1013,6 +1037,32 @@ EFFICIENCY_SENSOR_DEFINITIONS:
         dependency_keys:
             battery_power: battery_power
             ac_power: ac_power
+
+PRODUCT_SENSOR_DEFINITIONS:
+    charge_power_limit:
+        key: charge_power_limit
+        unit: W
+        device_class: power
+        state_class: measurement
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:battery-arrow-up"
+        max_value: 2500
+        dependency_keys:
+            factor_a: bms_charge_current_limit
+            factor_b: battery_voltage
+    discharge_power_limit:
+        key: discharge_power_limit
+        unit: W
+        device_class: power
+        state_class: measurement
+        category: diagnostic
+        enabled_by_default: false
+        icon: "mdi:battery-arrow-down"
+        max_value: 2500
+        dependency_keys:
+            factor_a: bms_discharge_current_limit
+            factor_b: battery_voltage
 
 STORED_ENERGY_SENSOR_DEFINITIONS:
     stored_energy:

--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -33,6 +33,7 @@ async def async_setup_entry(
     sensor_groups = (
         (MarstekSensor, coordinator.SENSOR_DEFINITIONS),
         (MarstekEfficiencySensor, coordinator.EFFICIENCY_SENSOR_DEFINITIONS),
+        (MarstekProductSensor, coordinator.PRODUCT_SENSOR_DEFINITIONS),
         (MarstekStoredEnergySensor, coordinator.STORED_ENERGY_SENSOR_DEFINITIONS),
         (MarstekBatteryCycleSensor, coordinator.CYCLE_SENSOR_DEFINITIONS),
     )
@@ -512,4 +513,18 @@ class MarstekBatteryCycleSensor(MarstekCalculatedSensor):
 
         cycles = round(discharge / capacity, 2)
         self._attr_native_value = cycles
-        return cycles
+
+
+class MarstekProductSensor(MarstekCalculatedSensor):
+    """Sensor calculating product: factor_a * factor_b, optionally capped by max_value."""
+
+    def calculate_value(self, dep_values: dict):
+        factor_a = dep_values.get("factor_a")
+        factor_b = dep_values.get("factor_b")
+        if factor_a is None or factor_b is None:
+            return None
+        result = factor_a * factor_b
+        max_value = self.definition.get("max_value")
+        if max_value is not None:
+            result = min(result, max_value)
+        return round(result, 1)

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -464,6 +464,18 @@
       "stored_energy": {
         "name": "Gespeicherte Energie"
       },
+      "bms_charge_current_limit": {
+        "name": "Maximaler BMS-Ladestrom"
+      },
+      "bms_discharge_current_limit": {
+        "name": "Maximaler BMS-Entladestrom"
+      },
+      "charge_power_limit": {
+        "name": "Maximale Ladeleistung"
+      },
+      "discharge_power_limit": {
+        "name": "Maximale Entladeleistung"
+      },
       "mppt1_voltage": {
         "name": "MPPT1 Spannung"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -467,6 +467,18 @@
       "stored_energy": {
         "name": "Stored Energy"
       },
+      "bms_charge_current_limit": {
+        "name": "BMS Charge Current Limit"
+      },
+      "bms_discharge_current_limit": {
+        "name": "BMS Discharge Current Limit"
+      },
+      "charge_power_limit": {
+        "name": "Charge Power Limit"
+      },
+      "discharge_power_limit": {
+        "name": "Discharge Power Limit"
+      },
       "mppt1_voltage": {
         "name": "MPPT1 Voltage"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -473,6 +473,18 @@
       "stored_energy": {
         "name": "Opgeslagen Energie"
       },
+      "bms_charge_current_limit": {
+        "name": "BMS laadstroom limiet"
+      },
+      "bms_discharge_current_limit": {
+        "name": "BMS ontlaadstroom limiet"
+      },
+      "charge_power_limit": {
+        "name": "Laadvermogen limiet"
+      },
+      "discharge_power_limit": {
+        "name": "Ontlaadvermogen limiet"
+      },
       "mppt1_voltage": {
         "name": "MPPT1 Spanning"
       },


### PR DESCRIPTION
Registers 35111 and 35112 appear to encode BMS-internal current limits (CCL/DCL) based on empirical observation across multiple sessions (2026-04-11). Values are SoC-dependent, remain constant within each snapshot while actual power varies (ruling out live EMS setpoints), and match observed power caps precisely when scaled by battery voltage.

## New Sensors

**Raw BMS limits (e_v3.yaml only):**
- `bms_charge_current_limit` — Register 35111, scale 0.1 A, diagnostic, disabled by default
- `bms_discharge_current_limit` — Register 35112, scale 0.1 A, diagnostic, disabled by default

**Calculated power limits:**
- `charge_power_limit` — `bms_charge_current_limit × battery_voltage`, capped at 2500 W
- `discharge_power_limit` — `bms_discharge_current_limit × battery_voltage`, capped at 2500 W

The cap at 2500 W reflects the hardware maximum. Values above that indicate no active BMS restriction; the power limit sensor then shows 2500 W (system max). Values below indicate the BMS is actively throttling.

Observed examples:
- 330 × 0.1 = 33 A → ~1782 W at 54 V (CV charge phase, matches observed 1800 W cap)
- 500 × 0.1 = 50 A → 2500 W at 50 V (discharge limit at SoC ~25%, exact match)

## Infrastructure

**New sensor class (`sensor.py`):**
- `MarstekProductSensor` — calculates `factor_a × factor_b`, supports optional `max_value` to cap the result

**New YAML section (`coordinator.py` + all register YAMLs):**
- `PRODUCT_SENSOR_DEFINITIONS`

## Translations

Updated de/en/nl translations for all four new sensors.