### PR TITLE
Fix char string decoding with embedded null bytes

### DIFF
--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -353,7 +353,11 @@ class MarstekModbusClient:
                         for reg in regs:
                             byte_array.append((reg >> 8) & 0xFF)
                             byte_array.append(reg & 0xFF)
-                        return byte_array.decode("ascii", errors="ignore").rstrip('\x00')
+                        # Truncate at first null byte (C-string semantics), then decode
+                        null_pos = byte_array.find(0)
+                        if null_pos >= 0:
+                            byte_array = byte_array[:null_pos]
+                        return byte_array.decode("ascii", errors="ignore")
 
                     elif data_type == "schedule":
                         # Return a decoded dict for schedule blocks.


### PR DESCRIPTION
## Problem

Modbus char registers (e.g. `device_name`, `mac_address`) are C-strings that use null bytes (`\x00`) as terminators. The previous implementation used `.rstrip('\x00')` which only strips trailing null bytes — embedded or leading null bytes passed through and appeared as garbage characters in Home Assistant. This happened for the `device_name` of Venus E Gen3, which returned ` VNSE3\x00-0`.

## Fix

Truncate the byte array at the first null byte before decoding, matching standard C-string semantics:

```python
null_pos = byte_array.find(0)
if null_pos >= 0:
    byte_array = byte_array[:null_pos]
return byte_array.decode("ascii", errors="ignore")
```

## Affected file

- `helpers/modbus_client.py`
