### PR TITLE
Fix battery_voltage precision and wifi_signal_strength device_class in e_v3.yaml

### DIFF
--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -1,8 +1,6 @@
-# Venus E v3 registers are untested.
-# Base register map generated from CSV (v3 Description).
-# Verify all addresses, names, and mappings on real hardware before use.
-# Some entries may be incorrect, duplicated, or unmatched.
-# See `# UNMATCHED_CSV_ENTRIES` at the end of this file.
+# Venus E v3 register map is partially validated on real hardware.
+# Verify addresses, names, and mappings against live device behavior before production use.
+# Some entries may still be incorrect, duplicated, or incomplete.
 
 MISSING:
     sensor:
@@ -91,7 +89,7 @@ SENSOR_DEFINITIONS:
         state_class: measurement
         enabled_by_default: true
         data_type: uint16
-        precision: 1
+        precision: 2
         scan_interval: medium
     battery_current:
         register: 30101
@@ -517,7 +515,7 @@ SENSOR_DEFINITIONS:
         register: 30303
         scale: -1
         data_type: uint16
-        device_class: diagnostic
+        device_class: signal_strength
         unit: dBm
         icon: "mdi:wifi"
         category: diagnostic

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -516,13 +516,13 @@
       }
     },
     "binary_sensor": {
-      "wifi_status": { 
+      "wifi_status": {
         "name": "WiFi Status" 
       },
-      "cloud_status": { 
+      "cloud_status": {
         "name": "Cloud Status" 
       },
-      "discharge_limit_mode": { 
+      "discharge_limit_mode": {
         "name": "Discharge Limit" 
       }
     },


### PR DESCRIPTION
## Problems

### 1. battery_voltage has wrong precision

The `battery_voltage` sensor had `precision: 1`, but register 30100 returns values like `5316` (= 53.16 V), so 2 decimal places are required.

### 2. wifi_signal_strength uses invalid device_class

The `wifi_signal_strength` sensor had `device_class: diagnostic` set. `diagnostic` is not a valid [HA sensor device class](https://www.home-assistant.io/integrations/sensor/#device-class) — it is an `entity_category` value. The correct device class is `signal_strength`, which also expects the unit `dBm` that was already set.

### 3. File header updated

The header comment said "untested" and referenced an unknown CSV source. It was updated to reflect the current state of the YAML file.

### 4. Whitespace fixes in EN translation

Some whitespaces have been removed.
