### PR TITLE
Add device_ip and gateway_ip sensors for Venus E v3

### DIFF
--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -220,7 +220,7 @@ class MarstekModbusClient:
         """
 
         if count is None:
-            count = 2 if data_type in ["int32", "uint32"] else 1
+            count = 2 if data_type in ["int32", "uint32", "ipv4"] else 1
 
         if not (0 <= register <= 0xFFFF):
             _LOGGER.error(
@@ -375,6 +375,21 @@ class MarstekModbusClient:
                             "mode": mode_signed,
                             "enabled": int(regs[4]),
                         }
+
+                    elif data_type == "ipv4":
+                        if len(regs) < 2:
+                            _LOGGER.warning(
+                                "Expected 2 registers for ipv4 at register %d (0x%04X), got %s",
+                                register,
+                                register,
+                                len(regs),
+                            )
+                            return None
+                        b1 = (regs[0] >> 8) & 0xFF
+                        b2 = regs[0] & 0xFF
+                        b3 = (regs[1] >> 8) & 0xFF
+                        b4 = regs[1] & 0xFF
+                        return f"{b1}.{b2}.{b3}.{b4}"
 
                     elif data_type == "bit":
                         if bit_index is None or not (0 <= bit_index < 16):

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -524,6 +524,20 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         precision: 0
         scan_interval: high
+    device_ip:
+        register: 30400
+        data_type: ipv4
+        icon: "mdi:ip-network"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: very_low
+    gateway_ip:
+        register: 30402
+        data_type: ipv4
+        icon: "mdi:ip-network-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: very_low
     bluetooth_status:
         register: 30301
         data_type: uint16

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -515,6 +515,7 @@ SENSOR_DEFINITIONS:
         scan_interval: high
     device_ip:
         register: 30400
+        count: 2
         data_type: ipv4
         icon: "mdi:ip-network"
         category: diagnostic
@@ -522,6 +523,7 @@ SENSOR_DEFINITIONS:
         scan_interval: very_low
     gateway_ip:
         register: 30402
+        count: 2
         data_type: ipv4
         icon: "mdi:ip-network-outline"
         category: diagnostic

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -524,6 +524,13 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         precision: 0
         scan_interval: high
+    bluetooth_status:
+        register: 30301
+        data_type: uint16
+        icon: "mdi:bluetooth"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: medium
     device_ip:
         register: 30400
         data_type: ipv4
@@ -538,13 +545,6 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: very_low
-    bluetooth_status:
-        register: 30301
-        data_type: uint16
-        icon: "mdi:bluetooth"
-        category: diagnostic
-        enabled_by_default: false
-        scan_interval: medium
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -513,6 +513,20 @@ SENSOR_DEFINITIONS:
         data_type: int16
         precision: 0
         scan_interval: high
+    device_ip:
+        register: 30400
+        data_type: ipv4
+        icon: "mdi:ip-network"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: very_low
+    gateway_ip:
+        register: 30402
+        data_type: ipv4
+        icon: "mdi:ip-network-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: very_low
     wifi_signal_strength:
         register: 30303
         scale: -1
@@ -531,20 +545,6 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: medium
-    device_ip:
-        register: 30400
-        data_type: ipv4
-        icon: "mdi:ip-network"
-        category: diagnostic
-        enabled_by_default: false
-        scan_interval: very_low
-    gateway_ip:
-        register: 30402
-        data_type: ipv4
-        icon: "mdi:ip-network-outline"
-        category: diagnostic
-        enabled_by_default: false
-        scan_interval: very_low
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -452,12 +452,6 @@
       "wifi_signal_strength": {
         "name": "WLAN-Signalstärke"
       },
-      "device_ip": {
-        "name": "Geräte-IP-Adresse"
-      },
-      "gateway_ip": {
-        "name": "Gateway-IP-Adresse"
-      },
       "round_trip_efficiency_total": {
         "name": "Gesamt-Roundtrip-Effizienz"
       },
@@ -515,6 +509,12 @@
           "3": "Aktiv",
           "4": "Gesperrt"
         }
+      },
+      "device_ip": {
+        "name": "Geräte-IP-Adresse"
+      },
+      "gateway_ip": {
+        "name": "Gateway-IP-Adresse"
       }
     },
     "binary_sensor": {

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -449,6 +449,12 @@
       "ac_offgrid_power": {
         "name": "AC-Offgrid-Leistung"
       },
+      "device_ip": {
+        "name": "Geräte-IP-Adresse"
+      },
+      "gateway_ip": {
+        "name": "Gateway-IP-Adresse"
+      },
       "wifi_signal_strength": {
         "name": "WLAN-Signalstärke"
       },
@@ -509,12 +515,6 @@
           "3": "Aktiv",
           "4": "Gesperrt"
         }
-      },
-      "device_ip": {
-        "name": "Geräte-IP-Adresse"
-      },
-      "gateway_ip": {
-        "name": "Gateway-IP-Adresse"
       }
     },
     "binary_sensor": {

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -452,6 +452,12 @@
       "wifi_signal_strength": {
         "name": "WLAN-Signalstärke"
       },
+      "device_ip": {
+        "name": "Geräte-IP-Adresse"
+      },
+      "gateway_ip": {
+        "name": "Gateway-IP-Adresse"
+      },
       "round_trip_efficiency_total": {
         "name": "Gesamt-Roundtrip-Effizienz"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -452,6 +452,12 @@
       "ac_offgrid_power": {
         "name": "AC Offgrid Power"
       },
+      "device_ip": {
+        "name": "Device IP Address"
+      },
+      "gateway_ip": {
+        "name": "Gateway IP Address"
+      },
       "wifi_signal_strength": {
         "name": "WiFi Signal Strength"
       },
@@ -513,12 +519,6 @@
           "3": "Active",
           "4": "Locked"
         }
-      },
-      "device_ip": {
-        "name": "Device IP Address"
-      },
-      "gateway_ip": {
-        "name": "Gateway IP Address"
       }
     },
     "binary_sensor": {

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -455,12 +455,6 @@
       "wifi_signal_strength": {
         "name": "WiFi Signal Strength"
       },
-      "device_ip": {
-        "name": "Device IP Address"
-      },
-      "gateway_ip": {
-        "name": "Gateway IP Address"
-      },
       "round_trip_efficiency_total": {
         "name": "Round Trip Efficiency Total"
       },
@@ -519,6 +513,12 @@
           "3": "Active",
           "4": "Locked"
         }
+      },
+      "device_ip": {
+        "name": "Device IP Address"
+      },
+      "gateway_ip": {
+        "name": "Gateway IP Address"
       }
     },
     "binary_sensor": {

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -455,6 +455,12 @@
       "wifi_signal_strength": {
         "name": "WiFi Signal Strength"
       },
+      "device_ip": {
+        "name": "Device IP Address"
+      },
+      "gateway_ip": {
+        "name": "Gateway IP Address"
+      },
       "round_trip_efficiency_total": {
         "name": "Round Trip Efficiency Total"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -458,6 +458,12 @@
       "ac_offgrid_power": {
         "name": "AC Off-grid Vermogen"
       },
+      "device_ip": {
+        "name": "Apparaat IP-adres"
+      },
+      "gateway_ip": {
+        "name": "Gateway IP-adres"
+      },
       "wifi_signal_strength": {
         "name": "WiFi-signaalsterkte"
       },
@@ -518,12 +524,6 @@
           "3": "Actief",
           "4": "Vergrendeld"
         }
-      },
-      "device_ip": {
-        "name": "Apparaat IP-adres"
-      },
-      "gateway_ip": {
-        "name": "Gateway IP-adres"
       }
     },
     "binary_sensor": {

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -461,12 +461,6 @@
       "wifi_signal_strength": {
         "name": "WiFi-signaalsterkte"
       },
-      "device_ip": {
-        "name": "Apparaat IP-adres"
-      },
-      "gateway_ip": {
-        "name": "Gateway IP-adres"
-      },
       "round_trip_efficiency_total": {
         "name": "Totaal rendement"
       },
@@ -524,6 +518,12 @@
           "3": "Actief",
           "4": "Vergrendeld"
         }
+      },
+      "device_ip": {
+        "name": "Apparaat IP-adres"
+      },
+      "gateway_ip": {
+        "name": "Gateway IP-adres"
       }
     },
     "binary_sensor": {

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -461,6 +461,12 @@
       "wifi_signal_strength": {
         "name": "WiFi-signaalsterkte"
       },
+      "device_ip": {
+        "name": "Apparaat IP-adres"
+      },
+      "gateway_ip": {
+        "name": "Gateway IP-adres"
+      },
       "round_trip_efficiency_total": {
         "name": "Totaal rendement"
       },


### PR DESCRIPTION
The Venus E v3 exposes the device IP address (register 30400) and gateway IP address (register 30402) via Modbus. Each address is stored across two consecutive registers as a 32-bit big-endian value (e.g. `0xC0A8` + `0x011F` = 192.168.1.31).

To support this, `ipv4` is added as a new `data_type` in `modbus_client.py`. It reads 2 registers and assembles them into a dotted-decimal IP string. The two new sensors in `e_v3.yaml` use this type and are disabled by default as diagnostic sensors.