### PR TITLE
Add scan_interval to diagnostic configuration

### DIFF
--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -656,6 +656,7 @@ SENSOR_DEFINITIONS:
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
+        scan_interval: medium
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:


### PR DESCRIPTION
Added scan_interval property to the configuration.

Deleted my fork cause i wanted to implement tmodbus.
But havn't seen that the BT fix wasnt implemented yet.