### PR TITLE
Improve smart polling and simplify scan interval configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # Changelog
+
+# [2026.6.2] - 2026-06-08
+
+### Added
+
+- Smart contiguous block polling for adjacent due registers, with automatic fallback to individual reads when a block request fails.
+- Combined `firmware_version` calculated sensor for all supported device profiles.
+- `ble_mac_address` diagnostic sensor with normalized MAC formatting.
+- `modbus_connection` diagnostic binary sensor with connection-health attributes.
+
+### Changed
+
+- Polling configuration simplified from four scan interval classes to two user-facing options: `high` and `low`.
+- Coordinator polling statistics and debug logging expanded to show block requests, single requests and failover behavior.
+- Register maps updated to use explicit firmware version composition modes (`ems_bms` and `ems_vms_bms`).
+- README updated to document simplified polling, smart block reads, supported device versions and new diagnostic entities.
+
+### Fixed
+
+- BLE MAC addresses are now decoded to a readable `AA:BB:CC:DD:EE:FF` format, including devices that expose the value as ASCII hex.
+- Firmware version composition corrected across `A`, `D`, `E v1/v2` and `E v3` register maps.
+
 # [2026.3.4] - 2026-03-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues/ViperRNMC/marstek_venus_modbus)](https://github.com/ViperRNMC/marstek_venus_modbus/issues)
 [![Downloads](https://img.shields.io/github/downloads/ViperRNMC/marstek_venus_modbus/total)](https://github.com/ViperRNMC/marstek_venus_modbus/releases)
 
-This is a custom HACS-compatible integration for the Marstek Venus E home battery system, using **Modbus TCP** via an **RS485-to-WiFi gateway**. No YAML required. The integration provides sensors, switches and number controls to monitor and manage the battery directly from Home Assistant.
+This is a custom HACS-compatible integration for Marstek Venus battery systems, using **Modbus TCP** via an **RS485-to-WiFi gateway** or direct Ethernet where supported. No YAML required. The integration provides sensors, switches and number controls to monitor and manage the battery directly from Home Assistant.
 
 
 ### 🧩 Requirements
@@ -19,10 +19,12 @@ This is a custom HACS-compatible integration for the Marstek Venus E home batter
 
 - Native Modbus TCP polling via `pymodbus`
 - Polling is handled centrally via the DataUpdateCoordinator with dynamic intervals per entity type
+- Smart contiguous block polling groups adjacent registers into single Modbus requests where possible, with automatic fallback to per-entity reads on failure
 - Configurable scan intervals via the integration options UI
 - Dependency entities are always polled, even if the related entity is disabled
 - Fully asynchronous operation for optimal performance and responsiveness
 - Sensors for voltage, current, SOC, power, energy, and fault/alarm status (combined bits)
+- Diagnostic entities for communication health, firmware version, BLE MAC address and communication-module firmware
 - Switches for force charge/discharge control
 - Adjustable charge/discharge power (model-dependent, up to 2500W)
 - Entities grouped under a device in Home Assistant
@@ -49,7 +51,7 @@ This is a custom HACS-compatible integration for the Marstek Venus E home batter
    - IP address of your Modbus TCP gateway
    - Port (default: 502)
    - Unit ID / Slave ID (default: 1, valid range: 1-255)
-   - Device version (v1/v2 or v3)
+  - Device version (`A`, `D`, `E v1/v2` or `E v3`)
 
 
 ## ⚙️ Configuration
@@ -58,11 +60,16 @@ This is a custom HACS-compatible integration for the Marstek Venus E home batter
 
 The integration uses intelligent polling with configurable intervals per entity type to balance responsiveness and network load.
 
+Recent versions use two polling classes instead of four. The coordinator still respects per-entity priorities, but the user-facing options are simplified to the intervals that matter most.
+
 **Configurable via Options UI:**
-- **High priority** (default: 5 seconds) - Critical sensors like power, voltage, current, SOC
-- **Medium priority** (default: 30 seconds) - Temperature sensors, state sensors
-- **Low priority** (default: 60 seconds) - Energy totals, efficiency calculations
-- **Very low priority** (default: 300 seconds) - Device information, firmware versions
+- **High priority** (default: 10 seconds) - Fast-changing sensors such as power, voltage, current, SOC and state entities
+- **Low priority** (default: 60 seconds) - Slower-changing sensors such as totals, diagnostics, firmware and device information
+
+Notes:
+- The coordinator will combine adjacent due registers into a single block read when possible.
+- If a block read fails, the integration falls back to individual reads for the affected entities.
+- Disabled entities are normally skipped, except when they are required as dependencies for calculated sensors.
 
 
 ## ✅ Tested Devices for Modbus TCP
@@ -97,7 +104,8 @@ Below is a per-key table showing descriptive fields and the register defined in 
 | bms_version                       | BMS firmware version                       | uint16  | 2    | -      | -    | 30204 | 30204 | 31102 | 30204 |
 | vms_version                       | VMS firmware version                       | uint16  | 2    | -      | -    | 30202 | 30202 |       | 30202 |
 | ems_version                       | EMS firmware version (special formatting)  | uint16  | 2    | 1      | -    | 30200 | 30200 | 31101 | 30200 |
-| mac_address                       | MAC address                                | char    | 12   | -      | -    | 30304 | 30304 | 30402 | 30304 |
+| firmware_version                  | Combined firmware version string           | calculated | - | - | - |  |  |  |  |
+| ble_mac_address                   | BLE MAC address                            | mac     | 12   | -      | -    | 30304 | 30304 | 30402 | 30304 |
 | comm_module_firmware              | Communication module firmware              | char    | 12   | -      | -    | 30350 | 30350 | 30800 | 30350 |
 | wifi_signal_strength              | WiFi RSSI                                  | uint16  | 2    | -1     | dBm  | 30303 | 30303 | 30303 | 30303 |
 | bluetooth_status                  | Bluetooth connectivity/status              | uint16  | 2    | -      | -    | 30301 | 30301 | 30301 | 30301 |
@@ -230,6 +238,7 @@ Below is a per-key table showing descriptive fields and the register defined in 
 | force_mode (select)               | Force mode (None/Charge/Discharge)         | uint16  | 2    | -      | -    | 42010 | 42010 | 42010 | 42010 |
 | user_work_mode (select)           | User Work Mode (manual/anti_feed/trade)    | uint16  | 2    | -      | -    | 43000 | 43000 | 43000 | 43000 |
 | discharge_limit_mode (binary)     | Discharge limit mode (diagnostic)          | uint16  | 2    | -      | -    |       |       | 41010 |       |
+| modbus_connection (binary)        | Modbus connection health                   | derived | -    | -      | -    |  |  |  |  |
 | grid_standard (select)            | Grid standard / region selection           | uint16  | 2    | -      | -    |       |       | 44100 |       |
 | charge_to_soc (number)            | Charge/discharge to SOC (0-100%)           | uint16  | 2    | 1      | %    | 42011 | 42011 | 42011 | 42011 |
 | set_charge_power (number)         | Forcible charge power setpoint             | uint16  | 2    | -      | W    | 42020 | 42020 | 42020 | 42020 |
@@ -280,6 +289,9 @@ _Notes:_
 - Columns `a`, `d`, `e_v12` and `e_v3` correspond to the YAML files under `custom_components/marstek_modbus/registers/`.
 - `Bytes` shows the typical byte size for the key (each Modbus register = 2 bytes).
 - Blank cells mean that YAML does not define that key (or the value is calculated and has no direct Modbus register).
+- `firmware_version` is assembled from the raw version registers. `E v1/v2` uses `ems + bms`; `A`, `D` and `E v3` use `ems + vms + bms`.
+- `ble_mac_address` is decoded and formatted as a normal MAC address string such as `00:9B:08:05:D9:0A`.
+- `modbus_connection` is a diagnostic binary sensor derived from recent successful Modbus reads, not from a separate device register.
 - The `rs485_control_mode` switch (register 42000) uses write commands (command_on=21930, command_off=21947) to trigger RS485 control operations; use with caution.
 - For access to registers in the 42000–42999 range, the battery must be set to RS485 control mode.
 - Schedule Time format: `start` and `end` are entered as HHMM 24-hour integers (for example `0830` = 08:30). Use values within the valid range shown in the YAML for each device; ensure `start` is earlier than `end` for a single active period.

--- a/custom_components/marstek_modbus/config_flow.py
+++ b/custom_components/marstek_modbus/config_flow.py
@@ -35,9 +35,7 @@ SCHEMA_HOST_BASE = vol.Schema(
 SCHEMA_POLLING = vol.Schema(
     {
         vol.Required("high"): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=3600)),
-        vol.Required("medium"): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=3600)),
         vol.Required("low"): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=3600)),
-        vol.Required("very_low"): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=3600)),
     }
 )
 
@@ -226,12 +224,19 @@ class MarstekOptionsFlow(config_entries.OptionsFlow):
         errors = {}
         config = self._config_entry
 
+        legacy_options = config.options or {}
+        normalized_options = dict(legacy_options)
+        if "high" not in normalized_options and "medium" in normalized_options:
+            normalized_options["high"] = normalized_options["medium"]
+        if "low" not in normalized_options and "very_low" in normalized_options:
+            normalized_options["low"] = normalized_options["very_low"]
+
         # Get defaults from options, then data, then constants
         defaults = {
-            key: config.options.get(
+            key: normalized_options.get(
                 key, config.data.get(key, DEFAULT_SCAN_INTERVALS[key])
             )
-            for key in ("high", "medium", "low", "very_low")
+            for key in ("high", "low")
         }
 
         # Calculate lowest scan interval for description
@@ -244,7 +249,15 @@ class MarstekOptionsFlow(config_entries.OptionsFlow):
 
             # Save and return to menu
             self.hass.config_entries.async_update_entry(
-                config, options={**config.options, **user_input}
+                config,
+                options={
+                    **{
+                        key: value
+                        for key, value in config.options.items()
+                        if key not in {"medium", "very_low"}
+                    },
+                    **user_input,
+                },
             )
             return await self.async_step_menu()
 

--- a/custom_components/marstek_modbus/const.py
+++ b/custom_components/marstek_modbus/const.py
@@ -12,10 +12,8 @@ DEFAULT_UNIT_ID = 1  # Default Modbus Unit ID (unit ID)
 
 # General scan intervals (in seconds)
 DEFAULT_SCAN_INTERVALS = {
-    "high": 10,       # fast-changing sensors, e.g., power, alarms
-    "medium": 30,     # moderately changing sensors, e.g., voltage, current
-    "low": 60,        # slow-changing sensors, e.g., cumulative energy counters
-    "very_low": 180   # rarely changing info, e.g., device info, firmware versions
+    "high": 10,      # fast-changing sensors and former medium-priority sensors
+    "low": 60,       # slower-changing sensors and former very_low-priority sensors
 }
 
 # Supported device versions

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DEFAULT_SCAN_INTERVALS, SUPPORTED_VERSIONS, DEFAULT_UNIT_ID
 
@@ -164,6 +164,57 @@ class MarstekCoordinator(DataUpdateCoordinator):
             self.update_interval,
         )
 
+    @staticmethod
+    def _definition_register_count(definition: dict) -> int:
+        """Return the register span needed for a definition."""
+        if definition.get("count") is not None:
+            return int(definition["count"])
+        data_type = definition.get("data_type", "uint16")
+        if data_type in {"int32", "uint32"}:
+            return 2
+        if data_type == "schedule":
+            return 5
+        return 1
+
+    def _build_contiguous_read_groups(self, sensors: list[dict]) -> list[list[dict]]:
+        """Group sensor definitions into strictly contiguous register blocks."""
+        if not sensors:
+            return []
+
+        ordered = sorted(sensors, key=lambda definition: definition["register"])
+        groups: list[list[dict]] = []
+        current_group: list[dict] = []
+        current_end: int | None = None
+
+        for sensor in ordered:
+            register = sensor["register"]
+            span = self._definition_register_count(sensor)
+            sensor_end = register + span - 1
+
+            if not current_group:
+                current_group = [sensor]
+                current_end = sensor_end
+                continue
+
+            if current_end is not None and register == current_end + 1 and sensor_end - current_group[0]["register"] < 125:
+                current_group.append(sensor)
+                current_end = sensor_end
+                continue
+
+            groups.append(current_group)
+            current_group = [sensor]
+            current_end = sensor_end
+
+        if current_group:
+            groups.append(current_group)
+
+        return groups
+
+    @staticmethod
+    def _definitions_by_key(definitions: list[dict]) -> dict[str, dict]:
+        """Return definitions indexed by key."""
+        return {definition["key"]: definition for definition in definitions}
+
 
     def register_entity_type(self, key: str, entity_type: str):
         """Register the entity type for a given sensor key.
@@ -282,7 +333,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
                 self.client.async_read_register(
                     register=sensor["register"],
                     data_type=sensor.get("data_type", "uint16"),
-                    count=sensor.get("count", 1),
+                    count=sensor.get("count"),
                     sensor_key=key,
                 ),
                 timeout=10.0
@@ -324,6 +375,88 @@ class MarstekCoordinator(DataUpdateCoordinator):
                 entity_type, key, sensor["register"], e,
             )
             return None
+
+    async def _async_read_contiguous_group(
+        self,
+        block_sensors: list[dict],
+        due_sensors: list[dict],
+    ) -> tuple[dict[str, object], dict[str, int]]:
+        """Read a contiguous block and decode due sensors, with per-sensor fallback on failure."""
+        if not block_sensors or not due_sensors:
+            return {}, {"requests": 0, "block_requests": 0, "fallback_requests": 0}
+
+        if len(block_sensors) == 1 and len(due_sensors) == 1:
+            sensor = due_sensors[0]
+            key = sensor["key"]
+            value = await self.async_read_value(sensor, key)
+            values = {key: value} if value is not None else {}
+            return values, {"requests": 1, "block_requests": 0, "fallback_requests": 1}
+
+        block_start = block_sensors[0]["register"]
+        block_end = max(sensor["register"] + self._definition_register_count(sensor) - 1 for sensor in block_sensors)
+        block_count = block_end - block_start + 1
+
+        block_registers = await self.client.async_read_holding_registers(
+            register=block_start,
+            count=block_count,
+            sensor_key=f"block:{block_sensors[0]['key']}+{len(block_sensors) - 1}",
+            max_retries=1,
+        )
+
+        if block_registers is None:
+            _LOGGER.debug(
+                "Contiguous block read failed for %d-%d; falling back to individual reads",
+                block_start,
+                block_end,
+            )
+            values: dict[str, object] = {}
+            for sensor in due_sensors:
+                key = sensor["key"]
+                value = await self.async_read_value(sensor, key)
+                if value is not None:
+                    values[key] = value
+            return values, {
+                "requests": 1 + len(due_sensors),
+                "block_requests": 1,
+                "fallback_requests": len(due_sensors),
+            }
+
+        values: dict[str, object] = {}
+        for sensor in due_sensors:
+            key = sensor["key"]
+            register = sensor["register"]
+            offset = register - block_start
+            span = self._definition_register_count(sensor)
+            raw_regs = block_registers[offset:offset + span]
+
+            try:
+                value = self.client._decode_registers(
+                    register=register,
+                    regs=raw_regs,
+                    data_type=sensor.get("data_type", "uint16"),
+                    bit_index=sensor.get("bit_index"),
+                )
+            except Exception as exc:
+                _LOGGER.debug(
+                    "Failed to decode block value for %s from registers %d-%d: %s",
+                    key,
+                    register,
+                    register + span - 1,
+                    exc,
+                )
+                value = None
+
+            if value is not None:
+                values[key] = value
+                _LOGGER.debug(
+                    "Updated %s '%s' from block read: register=%d, value=%s",
+                    self._entity_types.get(key, get_entity_type(sensor)),
+                    key,
+                    register,
+                    value,
+                )
+
+        return values, {"requests": 1, "block_requests": 1, "fallback_requests": 0}
 
     async def async_write_value(
         self,
@@ -495,7 +628,14 @@ class MarstekCoordinator(DataUpdateCoordinator):
         for dep_key in dependency_keys_set:
             _LOGGER.debug("Dependency key '%s'", dep_key)
 
-        # Iterate over each sensor definition to poll if due
+        due_sensors: list[dict] = []
+        readable_sensors: list[dict] = []
+        grouped_blocks = 0
+        top_level_requests = 0
+        block_requests = 0
+        fallback_requests = 0
+
+        # Iterate over each sensor definition to determine if it should be polled now
         for sensor in self._all_definitions:
             key = sensor["key"]
             entity_type = self._entity_types.get(key, get_entity_type(sensor))
@@ -518,6 +658,8 @@ class MarstekCoordinator(DataUpdateCoordinator):
                 else:
                     _LOGGER.debug("Skipping disabled entity '%s'", sensor.get("name", key))
                     continue
+
+            readable_sensors.append(sensor)
 
             # Determine polling interval for this sensor, using self.scan_intervals
             interval_name = sensor.get("scan_interval")
@@ -559,114 +701,129 @@ class MarstekCoordinator(DataUpdateCoordinator):
                 )
                 continue
 
-            # Track that we're attempting a read
-            attempted_reads += 1
-            self._read_start_times[key] = now
+            due_sensors.append(sensor)
 
-            # Attempt to read the sensor value from Modbus using helper function
-            value = await self.async_read_value(sensor, key)
+        due_by_key = self._definitions_by_key(due_sensors)
 
-            if value is not None:
-                # For total_increasing sensors, ignore suspicious drops/10x glitches,
-                # but do not fail the whole coordinator cycle.
-                # Daily/monthly counters may legitimately reset and are excluded.
-                if sensor.get("state_class") == "total_increasing" and isinstance(value, (int, float)):
-                    allow_reset = "_daily_" in key or "_monthly_" in key
-                    if not allow_reset:
-                        previous_value = self.data.get(key) if isinstance(self.data, dict) else None
-                        if isinstance(previous_value, (int, float)):
-                            regression = value < previous_value
-                            scale_glitch = (
-                                previous_value > 0
-                                and 0.08 <= (value / previous_value) <= 0.12
-                            )
-                            if regression or scale_glitch:
-                                reason = "regression" if regression else "possible 10x scaling glitch"
-                                _LOGGER.warning(
-                                    "Ignoring suspicious %s for total_increasing sensor '%s' (new=%s, previous=%s)",
-                                    reason,
-                                    key,
-                                    value,
-                                    previous_value,
+        for block_group in self._build_contiguous_read_groups(readable_sensors):
+            group_due_sensors = [sensor for sensor in block_group if sensor["key"] in due_by_key]
+            if not group_due_sensors:
+                continue
+
+            grouped_blocks += 1
+            group_values, group_stats = await self._async_read_contiguous_group(block_group, group_due_sensors)
+            top_level_requests += group_stats["requests"]
+            block_requests += group_stats["block_requests"]
+            fallback_requests += group_stats["fallback_requests"]
+
+            for sensor in group_due_sensors:
+                key = sensor["key"]
+                entity_type = self._entity_types.get(key, get_entity_type(sensor))
+                interval_name = sensor.get("scan_interval")
+                interval = self.scan_intervals.get(interval_name) if interval_name else None
+
+                attempted_reads += 1
+                self._read_start_times[key] = now
+                value = group_values.get(key)
+
+                if value is not None:
+                    # For total_increasing sensors, ignore suspicious drops/10x glitches,
+                    # but do not fail the whole coordinator cycle.
+                    # Daily/monthly counters may legitimately reset and are excluded.
+                    if sensor.get("state_class") == "total_increasing" and isinstance(value, (int, float)):
+                        allow_reset = "_daily_" in key or "_monthly_" in key
+                        if not allow_reset:
+                            previous_value = self.data.get(key) if isinstance(self.data, dict) else None
+                            if isinstance(previous_value, (int, float)):
+                                regression = value < previous_value
+                                scale_glitch = (
+                                    previous_value > 0
+                                    and 0.08 <= (value / previous_value) <= 0.12
                                 )
-                                self._last_attempt_times[key] = now
-                                continue
+                                if regression or scale_glitch:
+                                    reason = "regression" if regression else "possible 10x scaling glitch"
+                                    _LOGGER.warning(
+                                        "Ignoring suspicious %s for total_increasing sensor '%s' (new=%s, previous=%s)",
+                                        reason,
+                                        key,
+                                        value,
+                                        previous_value,
+                                    )
+                                    self._last_attempt_times[key] = now
+                                    continue
 
-                # Special-case: for packed schedule sensors, store both the
-                # raw 5-register list as the main `data[key]` and the decoded
-                # dict under `data["<key>_attrs"]` so sensors can expose
-                # attributes while the state remains the raw registers.
-                if sensor.get("data_type") == "schedule" and isinstance(value, dict):
-                    try:
-                        days = int(value.get("days") or 0)
-                    except Exception:
-                        days = value.get("days")
-                    try:
-                        start = int(value.get("start") or 0)
-                    except Exception:
-                        start = value.get("start")
-                    try:
-                        end = int(value.get("end") or 0)
-                    except Exception:
-                        end = value.get("end")
-                    try:
-                        enabled = int(value.get("enabled") or 0)
-                    except Exception:
-                        enabled = value.get("enabled")
+                    # Special-case: for packed schedule sensors, store both the
+                    # raw 5-register list as the main `data[key]` and the decoded
+                    # dict under `data["<key>_attrs"]` so sensors can expose
+                    # attributes while the state remains the raw registers.
+                    if sensor.get("data_type") == "schedule" and isinstance(value, dict):
+                        try:
+                            days = int(value.get("days") or 0)
+                        except Exception:
+                            days = value.get("days")
+                        try:
+                            start = int(value.get("start") or 0)
+                        except Exception:
+                            start = value.get("start")
+                        try:
+                            end = int(value.get("end") or 0)
+                        except Exception:
+                            end = value.get("end")
+                        try:
+                            enabled = int(value.get("enabled") or 0)
+                        except Exception:
+                            enabled = value.get("enabled")
 
-                    # Mode in attrs is signed; convert to unsigned 16-bit for raw register
-                    try:
-                        mode_signed = int(value.get("mode") or 0)
-                        mode_raw = mode_signed & 0xFFFF
-                    except Exception:
-                        mode_raw = value.get("mode")
+                        try:
+                            mode_signed = int(value.get("mode") or 0)
+                            mode_raw = mode_signed & 0xFFFF
+                        except Exception:
+                            mode_raw = value.get("mode")
 
-                    raw_regs = [days, start, end, mode_raw, enabled]
+                        raw_regs = [days, start, end, mode_raw, enabled]
 
-                    updated_data[key] = raw_regs
-                    try:
-                        updated_data[f"{key}_attrs"] = value
-                    except Exception:
-                        _LOGGER.exception("Failed to populate %s_attrs", key)
+                        updated_data[key] = raw_regs
+                        try:
+                            updated_data[f"{key}_attrs"] = value
+                        except Exception:
+                            _LOGGER.exception("Failed to populate %s_attrs", key)
 
-                    _LOGGER.debug(
-                        "Stored raw schedule for %s: %s and attrs: %s",
-                        key,
-                        raw_regs,
-                        value,
-                    )
+                        _LOGGER.debug(
+                            "Stored raw schedule for %s: %s and attrs: %s",
+                            key,
+                            raw_regs,
+                            value,
+                        )
+                    else:
+                        updated_data[key] = value
+
+                    self._last_update_times[key] = now
+                    self._last_attempt_times[key] = now
+                    prev_failures = self._register_failures.get(key, 0)
+                    if prev_failures > 0:
+                        _LOGGER.info(
+                            "%s '%s' recovered after %d consecutive failure(s)",
+                            entity_type, key, prev_failures,
+                        )
+                    self._register_failures[key] = 0
+                    successful_reads += 1
                 else:
-                    updated_data[key] = value
-
-                self._last_update_times[key] = now
-                self._last_attempt_times[key] = now
-                prev_failures = self._register_failures.get(key, 0)
-                if prev_failures > 0:
-                    _LOGGER.info(
-                        "%s '%s' recovered after %d consecutive failure(s)",
-                        entity_type, key, prev_failures,
-                    )
-                self._register_failures[key] = 0
-                successful_reads += 1
-            else:
-                # Individual sensor read failed — increment backoff counter
-                self._last_attempt_times[key] = now
-                new_failures = self._register_failures.get(key, 0) + 1
-                self._register_failures[key] = new_failures
-                next_backoff = min(2 ** new_failures, 64)
-                next_interval = min(interval * next_backoff, 3600)
-                # Log verbosely on first few failures and then only at milestones
-                if new_failures <= 3 or new_failures % 10 == 0:
-                    _LOGGER.warning(
-                        "Failed to read %s '%s' - value is None "
-                        "(consecutive failures: %d, next poll in %ds)",
-                        entity_type, key, new_failures, next_interval,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Failed to read %s '%s' - value is None (failure #%d)",
-                        entity_type, key, new_failures,
-                    )
+                    self._last_attempt_times[key] = now
+                    new_failures = self._register_failures.get(key, 0) + 1
+                    self._register_failures[key] = new_failures
+                    next_backoff = min(2 ** new_failures, 64)
+                    next_interval = min((interval or 30) * next_backoff, 3600)
+                    if new_failures <= 3 or new_failures % 10 == 0:
+                        _LOGGER.warning(
+                            "Failed to read %s '%s' - value is None "
+                            "(consecutive failures: %d, next poll in %ds)",
+                            entity_type, key, new_failures, next_interval,
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "Failed to read %s '%s' - value is None (failure #%d)",
+                            entity_type, key, new_failures,
+                        )
 
         # Connection retry logic: only track failures if we actually attempted reads
         if attempted_reads > 0:
@@ -740,6 +897,16 @@ class MarstekCoordinator(DataUpdateCoordinator):
                 self._consecutive_timeout_cycles = 0
         else:
             _LOGGER.debug("No sensors due for update in this cycle")
+
+        _LOGGER.debug(
+            "Polling summary: due=%d, groups=%d, requests=%d, block_requests=%d, fallback_requests=%d, successful_reads=%d",
+            len(due_sensors),
+            grouped_blocks,
+            top_level_requests,
+            block_requests,
+            fallback_requests,
+            successful_reads,
+        )
 
         # Defensive check
         if self.data is None:

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -134,12 +134,18 @@ class MarstekCoordinator(DataUpdateCoordinator):
         old_intervals = getattr(self, "scan_intervals", {}).copy() if hasattr(self, "scan_intervals") else {}
         self.scan_intervals = DEFAULT_SCAN_INTERVALS.copy()
 
+        normalized_options = dict(options)
+        if "high" not in normalized_options and "medium" in normalized_options:
+            normalized_options["high"] = normalized_options["medium"]
+        if "low" not in normalized_options and "very_low" in normalized_options:
+            normalized_options["low"] = normalized_options["very_low"]
+
         for key in DEFAULT_SCAN_INTERVALS:
-            if key in options:
+            if key in normalized_options:
                 try:
-                    self.scan_intervals[key] = int(options[key])
+                    self.scan_intervals[key] = int(normalized_options[key])
                 except Exception:
-                    _LOGGER.warning("Invalid scan interval for %s: %s", key, options[key])
+                    _LOGGER.warning("Invalid scan interval for %s: %s", key, normalized_options[key])
 
         # Compute minimum interval for coordinator
         min_interval = min(self.scan_intervals.values()) if self.scan_intervals else 30
@@ -343,7 +349,7 @@ class MarstekCoordinator(DataUpdateCoordinator):
             # by specialized data_type handlers (e.g., `schedule` returning a dict).
             if isinstance(value, (int, float, bool, str, dict, list)):
                 _LOGGER.debug(
-                     "Updated %s '%s': register=%d, value=%s, scale=%s, unit=%s",
+                     "Updated %s '%s' from single read: register=%d, value=%s, scale=%s, unit=%s",
                     entity_type,
                     key,
                     sensor["register"],
@@ -383,23 +389,24 @@ class MarstekCoordinator(DataUpdateCoordinator):
     ) -> tuple[dict[str, object], dict[str, int]]:
         """Read a contiguous block and decode due sensors, with per-sensor fallback on failure."""
         if not block_sensors or not due_sensors:
-            return {}, {"requests": 0, "block_requests": 0, "fallback_requests": 0}
+            return {}, {"requests": 0, "block_requests": 0, "single_requests": 0, "failover_single_requests": 0}
 
         if len(block_sensors) == 1 and len(due_sensors) == 1:
             sensor = due_sensors[0]
             key = sensor["key"]
             value = await self.async_read_value(sensor, key)
             values = {key: value} if value is not None else {}
-            return values, {"requests": 1, "block_requests": 0, "fallback_requests": 1}
+            return values, {"requests": 1, "block_requests": 0, "single_requests": 1, "failover_single_requests": 0}
 
-        block_start = block_sensors[0]["register"]
-        block_end = max(sensor["register"] + self._definition_register_count(sensor) - 1 for sensor in block_sensors)
+        block_start = min(sensor["register"] for sensor in due_sensors)
+        block_end = max(sensor["register"] + self._definition_register_count(sensor) - 1 for sensor in due_sensors)
         block_count = block_end - block_start + 1
+        sensor_keys = ",".join(sensor["key"] for sensor in due_sensors)
 
         block_registers = await self.client.async_read_holding_registers(
             register=block_start,
             count=block_count,
-            sensor_key=f"block:{block_sensors[0]['key']}+{len(block_sensors) - 1}",
+            sensor_key=f"block[{sensor_keys}]",
             max_retries=1,
         )
 
@@ -418,7 +425,8 @@ class MarstekCoordinator(DataUpdateCoordinator):
             return values, {
                 "requests": 1 + len(due_sensors),
                 "block_requests": 1,
-                "fallback_requests": len(due_sensors),
+                "single_requests": len(due_sensors),
+                "failover_single_requests": len(due_sensors),
             }
 
         values: dict[str, object] = {}
@@ -428,6 +436,9 @@ class MarstekCoordinator(DataUpdateCoordinator):
             offset = register - block_start
             span = self._definition_register_count(sensor)
             raw_regs = block_registers[offset:offset + span]
+            entity_type = self._entity_types.get(key, get_entity_type(sensor))
+            scale = self._scales.get(key, sensor.get("scale", 1))
+            unit = sensor.get("unit", "N/A")
 
             try:
                 value = self.client._decode_registers(
@@ -449,14 +460,16 @@ class MarstekCoordinator(DataUpdateCoordinator):
             if value is not None:
                 values[key] = value
                 _LOGGER.debug(
-                    "Updated %s '%s' from block read: register=%d, value=%s",
-                    self._entity_types.get(key, get_entity_type(sensor)),
+                    "Updated %s '%s' from block read: register=%d, value=%s, scale=%s, unit=%s",
+                    entity_type,
                     key,
                     register,
                     value,
+                    scale,
+                    unit,
                 )
 
-        return values, {"requests": 1, "block_requests": 1, "fallback_requests": 0}
+        return values, {"requests": 1, "block_requests": 1, "single_requests": 0, "failover_single_requests": 0}
 
     async def async_write_value(
         self,
@@ -633,7 +646,8 @@ class MarstekCoordinator(DataUpdateCoordinator):
         grouped_blocks = 0
         top_level_requests = 0
         block_requests = 0
-        fallback_requests = 0
+        single_requests = 0
+        failover_single_requests = 0
 
         # Iterate over each sensor definition to determine if it should be polled now
         for sensor in self._all_definitions:
@@ -714,7 +728,8 @@ class MarstekCoordinator(DataUpdateCoordinator):
             group_values, group_stats = await self._async_read_contiguous_group(block_group, group_due_sensors)
             top_level_requests += group_stats["requests"]
             block_requests += group_stats["block_requests"]
-            fallback_requests += group_stats["fallback_requests"]
+            single_requests += group_stats["single_requests"]
+            failover_single_requests += group_stats["failover_single_requests"]
 
             for sensor in group_due_sensors:
                 key = sensor["key"]
@@ -899,12 +914,13 @@ class MarstekCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("No sensors due for update in this cycle")
 
         _LOGGER.debug(
-            "Polling summary: due=%d, groups=%d, requests=%d, block_requests=%d, fallback_requests=%d, successful_reads=%d",
+            "Polling summary: due=%d, groups=%d, requests=%d, block_requests=%d, single_requests=%d, failover_single_requests=%d, successful_reads=%d",
             len(due_sensors),
             grouped_blocks,
             top_level_requests,
             block_requests,
-            fallback_requests,
+            single_requests,
+            failover_single_requests,
             successful_reads,
         )
 

--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -367,23 +367,41 @@ class MarstekModbusClient:
                     )
                 else:
                     regs = list(result.registers)
-                    _LOGGER.debug(
-                        "Requesting register block %d-%d (0x%04X-0x%04X) from '%s' for sensor '%s' (count: %s)",
-                        register,
-                        register + count - 1,
-                        register,
-                        register + count - 1,
-                        self.host,
-                        sensor_key or "unknown",
-                        count,
-                    )
-                    _LOGGER.debug(
-                        "Received block data from '%s' for register %d (0x%04X): %s",
-                        self.host,
-                        register,
-                        register,
-                        regs,
-                    )
+                    if count == 1:
+                        _LOGGER.debug(
+                            "Requesting single register %d (0x%04X) from '%s' for key '%s'",
+                            register,
+                            register,
+                            self.host,
+                            sensor_key or "unknown",
+                        )
+                        _LOGGER.debug(
+                            "Received single register data from '%s' for register %d (0x%04X): %s",
+                            self.host,
+                            register,
+                            register,
+                            regs,
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "Requesting register block %d-%d (0x%04X-0x%04X) from '%s' for keys '%s' (count: %s)",
+                            register,
+                            register + count - 1,
+                            register,
+                            register + count - 1,
+                            self.host,
+                            sensor_key or "unknown",
+                            count,
+                        )
+                        _LOGGER.debug(
+                            "Received block data from '%s' for registers %d-%d (0x%04X-0x%04X): %s",
+                            self.host,
+                            register,
+                            register + count - 1,
+                            register,
+                            register + count - 1,
+                            regs,
+                        )
                     return regs
 
             except asyncio.CancelledError:
@@ -451,15 +469,6 @@ class MarstekModbusClient:
         if regs is None:
             return None
 
-        _LOGGER.debug(
-            "Decoding register %d (0x%04X) from '%s' for sensor '%s' (type: %s, count: %s)",
-            register,
-            register,
-            self.host,
-            sensor_key or "unknown",
-            data_type,
-            count,
-        )
         return self._decode_registers(
             register=register,
             regs=regs,

--- a/custom_components/marstek_modbus/helpers/modbus_client.py
+++ b/custom_components/marstek_modbus/helpers/modbus_client.py
@@ -193,35 +193,99 @@ class MarstekModbusClient:
                 _LOGGER.warning("Unhandled exception during reconnect: %s", e)
                 return False
 
-    async def async_read_register(
+    @staticmethod
+    def _default_count_for_data_type(data_type: str) -> int:
+        """Return the default register count for a given data type."""
+        if data_type in {"int32", "uint32"}:
+            return 2
+        if data_type == "schedule":
+            return 5
+        return 1
+
+    def _decode_registers(
         self,
         register: int,
+        regs: list[int],
         data_type: str = "uint16",
-        count: Optional[int] = None,
         bit_index: Optional[int] = None,
+    ):
+        """Decode raw holding registers into the requested data type."""
+        if data_type == "int16":
+            val = regs[0]
+            return val - 0x10000 if val >= 0x8000 else val
+
+        if data_type == "uint16":
+            return regs[0]
+
+        if data_type == "int32":
+            if len(regs) < 2:
+                _LOGGER.warning(
+                    "Expected 2 registers for int32 at register %d (0x%04X), got %s",
+                    register,
+                    register,
+                    len(regs),
+                )
+                return None
+            val = (regs[0] << 16) | regs[1]
+            return val - 0x100000000 if val >= 0x80000000 else val
+
+        if data_type == "uint32":
+            if len(regs) < 2:
+                _LOGGER.warning(
+                    "Expected 2 registers for uint32 at register %d (0x%04X), got %s",
+                    register,
+                    register,
+                    len(regs),
+                )
+                return None
+            return (regs[0] << 16) | regs[1]
+
+        if data_type == "char":
+            byte_array = bytearray()
+            for reg in regs:
+                byte_array.append((reg >> 8) & 0xFF)
+                byte_array.append(reg & 0xFF)
+            null_pos = byte_array.find(0)
+            if null_pos >= 0:
+                byte_array = byte_array[:null_pos]
+            return byte_array.decode("ascii", errors="ignore")
+
+        if data_type == "schedule":
+            if len(regs) < 5:
+                _LOGGER.warning(
+                    "Expected 5 registers for schedule at %d (0x%04X), got %s",
+                    register,
+                    register,
+                    len(regs),
+                )
+                return None
+            mode_raw = int(regs[3])
+            mode_signed = mode_raw - 0x10000 if mode_raw >= 0x8000 else mode_raw
+            return {
+                "days": int(regs[0]),
+                "start": int(regs[1]),
+                "end": int(regs[2]),
+                "mode": mode_signed,
+                "enabled": int(regs[4]),
+            }
+
+        if data_type == "bit":
+            if bit_index is None or not (0 <= bit_index < 16):
+                raise ValueError("bit_index must be between 0 and 15 for bit data_type")
+            reg_val = regs[0]
+            return bool((reg_val >> bit_index) & 1)
+
+        raise ValueError(f"Unsupported data_type: {data_type}")
+
+    async def async_read_holding_registers(
+        self,
+        register: int,
+        count: int,
         sensor_key: Optional[str] = None,
         max_retries: int = 3,
         retry_delay: float = 0.1,
-    ):
-        """
-        Robustly read registers and interpret the data asynchronously with retries.
-
-        Args:
-            register (int): Register address to read from.
-            data_type (str): Data type for interpretation, e.g. 'int16', 'int32', 'char', 'bit'.
-            count (Optional[int]): Number of registers to read (default depends on data_type).
-            bit_index (Optional[int]): Bit position for 'bit' data type (0-15).
-            sensor_key (Optional[str]): Sensor key for logging.
-            max_retries (int): Maximum number of read attempts.
-            retry_delay (float): Delay in seconds between retries.
-
-        Returns:
-            int, str, bool, or None: Interpreted value or None on error.
-        """
-
-        if count is None:
-            count = 2 if data_type in ["int32", "uint32"] else 1
-
+    ) -> list[int] | None:
+        """Read raw holding registers asynchronously with retries."""
         if not (0 <= register <= 0xFFFF):
             _LOGGER.error(
                 "Invalid register address: %d (0x%04X). Must be 0-65535.",
@@ -230,7 +294,7 @@ class MarstekModbusClient:
             )
             return None
 
-        if not (1 <= count <= 125):  # Modbus spec limit
+        if not (1 <= count <= 125):
             _LOGGER.error(
                 "Invalid register count: %d. Must be between 1 and 125.",
                 count,
@@ -239,7 +303,6 @@ class MarstekModbusClient:
 
         attempt = 0
         while attempt < max_retries:
-            # Guard against client being None (closed during unload)
             client_connected = False
             try:
                 client_connected = bool(self.client and getattr(self.client, "connected", False))
@@ -263,10 +326,8 @@ class MarstekModbusClient:
 
             try:
                 result = None
-                # Serialize Modbus requests to avoid overlapping frames and transaction id mismatches
                 async with self._request_lock:
                     try:
-                        # Try multiple kwarg names for different pymodbus versions
                         read_method = getattr(self.client, "read_holding_registers")
                         for unit_kw in ("device_id", "unit", "slave"):
                             try:
@@ -276,7 +337,6 @@ class MarstekModbusClient:
                                 result = None
                                 continue
                     finally:
-                        # Short spacing after each request to give the device time
                         try:
                             await asyncio.sleep(self.message_wait_sec)
                         except asyncio.CancelledError:
@@ -306,95 +366,29 @@ class MarstekModbusClient:
                         len(result.registers) if result.registers else 0,
                     )
                 else:
-                    regs = result.registers
+                    regs = list(result.registers)
                     _LOGGER.debug(
-                        "Requesting register %d (0x%04X) from '%s' for sensor '%s' (type: %s, count: %s)",
+                        "Requesting register block %d-%d (0x%04X-0x%04X) from '%s' for sensor '%s' (count: %s)",
                         register,
+                        register + count - 1,
                         register,
+                        register + count - 1,
                         self.host,
-                        sensor_key or 'unknown',
-                        data_type,
+                        sensor_key or "unknown",
                         count,
                     )
-                    _LOGGER.debug("Received data from '%s' for register %d (0x%04X): %s", self.host, register, register, regs)
-
-                    if data_type == "int16":
-                        val = regs[0]
-                        return val - 0x10000 if val >= 0x8000 else val
-
-                    elif data_type == "uint16":
-                        return regs[0]
-
-                    elif data_type == "int32":
-                        if len(regs) < 2:
-                            _LOGGER.warning(
-                                "Expected 2 registers for int32 at register %d (0x%04X), got %s",
-                                register,
-                                register,
-                                len(regs),
-                            )
-                            return None
-                        val = (regs[0] << 16) | regs[1]
-                        return val - 0x100000000 if val >= 0x80000000 else val
-
-                    elif data_type == "uint32":
-                        if len(regs) < 2:
-                            _LOGGER.warning(
-                                "Expected 2 registers for uint32 at register %d (0x%04X), got %s",
-                                register,
-                                register,
-                                len(regs),
-                            )
-                            return None
-                        return (regs[0] << 16) | regs[1]
-
-                    elif data_type == "char":
-                        byte_array = bytearray()
-                        for reg in regs:
-                            byte_array.append((reg >> 8) & 0xFF)
-                            byte_array.append(reg & 0xFF)
-                        # Truncate at first null byte (C-string semantics), then decode
-                        null_pos = byte_array.find(0)
-                        if null_pos >= 0:
-                            byte_array = byte_array[:null_pos]
-                        return byte_array.decode("ascii", errors="ignore")
-
-                    elif data_type == "schedule":
-                        # Return a decoded dict for schedule blocks.
-                        # 5 registers: days, start, end, mode (int16 signed), enabled
-                        if len(regs) < 5:
-                            _LOGGER.warning(
-                                "Expected 5 registers for schedule at %d (0x%04X), got %s",
-                                register,
-                                register,
-                                len(regs),
-                            )
-                            return None
-                        mode_raw = int(regs[3])
-                        mode_signed = mode_raw - 0x10000 if mode_raw >= 0x8000 else mode_raw
-                        return {
-                            "days": int(regs[0]),
-                            "start": int(regs[1]),
-                            "end": int(regs[2]),
-                            "mode": mode_signed,
-                            "enabled": int(regs[4]),
-                        }
-
-                    elif data_type == "bit":
-                        if bit_index is None or not (0 <= bit_index < 16):
-                            raise ValueError("bit_index must be between 0 and 15 for bit data_type")
-                        reg_val = regs[0]
-                        return bool((reg_val >> bit_index) & 1)
-
-                    else:
-                        raise ValueError(f"Unsupported data_type: {data_type}")
+                    _LOGGER.debug(
+                        "Received block data from '%s' for register %d (0x%04X): %s",
+                        self.host,
+                        register,
+                        register,
+                        regs,
+                    )
+                    return regs
 
             except asyncio.CancelledError:
-                # Allow cancellation to propagate during Home Assistant shutdown
                 raise
             except Exception as e:
-                # If the underlying cause is a CancelledError (pymodbus wraps it),
-                # propagate it so shutdown is not logged as an error.
                 cause = getattr(e, "__cause__", None)
                 if isinstance(cause, asyncio.CancelledError):
                     raise cause
@@ -418,6 +412,60 @@ class MarstekModbusClient:
             max_retries,
         )
         return None
+
+    async def async_read_register(
+        self,
+        register: int,
+        data_type: str = "uint16",
+        count: Optional[int] = None,
+        bit_index: Optional[int] = None,
+        sensor_key: Optional[str] = None,
+        max_retries: int = 3,
+        retry_delay: float = 0.1,
+    ):
+        """
+        Robustly read registers and interpret the data asynchronously with retries.
+
+        Args:
+            register (int): Register address to read from.
+            data_type (str): Data type for interpretation, e.g. 'int16', 'int32', 'char', 'bit'.
+            count (Optional[int]): Number of registers to read (default depends on data_type).
+            bit_index (Optional[int]): Bit position for 'bit' data type (0-15).
+            sensor_key (Optional[str]): Sensor key for logging.
+            max_retries (int): Maximum number of read attempts.
+            retry_delay (float): Delay in seconds between retries.
+
+        Returns:
+            int, str, bool, or None: Interpreted value or None on error.
+        """
+        if count is None:
+            count = self._default_count_for_data_type(data_type)
+
+        regs = await self.async_read_holding_registers(
+            register=register,
+            count=count,
+            sensor_key=sensor_key,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+        if regs is None:
+            return None
+
+        _LOGGER.debug(
+            "Decoding register %d (0x%04X) from '%s' for sensor '%s' (type: %s, count: %s)",
+            register,
+            register,
+            self.host,
+            sensor_key or "unknown",
+            data_type,
+            count,
+        )
+        return self._decode_registers(
+            register=register,
+            regs=regs,
+            data_type=data_type,
+            bit_index=bit_index,
+        )
 
     async def async_write_register(
         self,

--- a/custom_components/marstek_modbus/manifest.json
+++ b/custom_components/marstek_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_modbus",
   "name": "Marstek Venus Modbus",
-  "version": "2026.5.1.b2",
+  "version": "2026.6.2.b1",
   "config_flow": true,
   "documentation": "https://github.com/viperrnmc/marstek_venus_modbus",
   "requirements": ["pymodbus>=3.9.2"],

--- a/custom_components/marstek_modbus/manifest.json
+++ b/custom_components/marstek_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_modbus",
   "name": "Marstek Venus Modbus",
-  "version": "2026.6.2.b1",
+  "version": "2026.6.2.b2",
   "config_flow": true,
   "documentation": "https://github.com/viperrnmc/marstek_venus_modbus",
   "requirements": ["pymodbus>=3.9.2"],

--- a/custom_components/marstek_modbus/registers/a.yaml
+++ b/custom_components/marstek_modbus/registers/a.yaml
@@ -25,21 +25,21 @@ SENSOR_DEFINITIONS:
         data_type: char
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
-        scan_interval: very_low
+        scan_interval: low
     bms_version:
         register: 30204
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     vms_version:
         register: 30202
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     ems_version:
         register: 30200
         category: diagnostic
@@ -47,7 +47,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        scan_interval: very_low
+        scan_interval: low
     comm_module_firmware:
         register: 30350
         count: 6
@@ -55,14 +55,14 @@ SENSOR_DEFINITIONS:
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     mac_address:
         register: 30304
         count: 6
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     battery_soc:
         register: 32104
         scale: 1
@@ -72,7 +72,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_soc_1:
         register: 34002
         scale: 0.1
@@ -81,7 +81,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_soc_2:
         register: 34102
         scale: 0.1
@@ -90,7 +90,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_soc_3:
         register: 34202
         scale: 0.1
@@ -99,7 +99,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_soc_4:
         register: 34302
         scale: 0.1
@@ -108,7 +108,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_soc_5:
         register: 34402
         scale: 0.1
@@ -117,7 +117,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_soc_6:
         register: 34502
         scale: 0.1
@@ -126,7 +126,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_total_energy:
         register: 32105
         scale: 0.001
@@ -146,7 +146,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_current:
         register: 30101
         scale: 0.1
@@ -156,7 +156,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_power:
         register: 30001
         count: 1
@@ -177,7 +177,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos1_temperature:
         register: 35001
         scale: 0.1
@@ -187,7 +187,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos2_temperature:
         register: 35002
         scale: 0.1
@@ -197,7 +197,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     ac_voltage:
         register: 32200
         scale: 0.1
@@ -207,7 +207,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_current:
         register: 37004
         scale: 0.004
@@ -217,7 +217,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_power:
         register: 30006
         count: 1
@@ -238,7 +238,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     total_charging_energy:
         register: 33000
         count: 2
@@ -324,7 +324,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     min_cell_temperature:
         register: 35011
         scale: 0.1
@@ -334,7 +334,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     max_cell_voltage:
         register: 37007
         scale: 0.001
@@ -344,7 +344,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     min_cell_voltage:
         register: 37008
         scale: 0.001
@@ -354,7 +354,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_1_voltage:
         register: 34018
         scale: 0.001
@@ -364,7 +364,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_2_voltage:
         register: 34019
         scale: 0.001
@@ -374,7 +374,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_3_voltage:
         register: 34020
         scale: 0.001
@@ -384,7 +384,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_4_voltage:
         register: 34021
         scale: 0.001
@@ -394,7 +394,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_5_voltage:
         register: 34022
         scale: 0.001
@@ -404,7 +404,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_6_voltage:
         register: 34023
         scale: 0.001
@@ -414,7 +414,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_7_voltage:
         register: 34024
         scale: 0.001
@@ -424,7 +424,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_8_voltage:
         register: 34025
         scale: 0.001
@@ -434,7 +434,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_9_voltage:
         register: 34026
         scale: 0.001
@@ -444,7 +444,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_10_voltage:
         register: 34027
         scale: 0.001
@@ -454,7 +454,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_11_voltage:
         register: 34028
         scale: 0.001
@@ -464,7 +464,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_12_voltage:
         register: 34029
         scale: 0.001
@@ -474,7 +474,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_13_voltage:
         register: 34030
         scale: 0.001
@@ -484,7 +484,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_1_voltage:
         register: 34118
         scale: 0.001
@@ -494,7 +494,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_2_voltage:
         register: 34119
         scale: 0.001
@@ -504,7 +504,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_3_voltage:
         register: 34120
         scale: 0.001
@@ -514,7 +514,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_4_voltage:
         register: 34121
         scale: 0.001
@@ -524,7 +524,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_5_voltage:
         register: 34122
         scale: 0.001
@@ -534,7 +534,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_6_voltage:
         register: 34123
         scale: 0.001
@@ -544,7 +544,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_7_voltage:
         register: 34124
         scale: 0.001
@@ -554,7 +554,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_8_voltage:
         register: 34125
         scale: 0.001
@@ -564,7 +564,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_9_voltage:
         register: 34126
         scale: 0.001
@@ -574,7 +574,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_10_voltage:
         register: 34127
         scale: 0.001
@@ -584,7 +584,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_11_voltage:
         register: 34128
         scale: 0.001
@@ -594,7 +594,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_12_voltage:
         register: 34129
         scale: 0.001
@@ -604,7 +604,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_2_cell_13_voltage:
         register: 34130
         scale: 0.001
@@ -614,7 +614,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_1_voltage:
         register: 34218
         scale: 0.001
@@ -624,7 +624,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_2_voltage:
         register: 34219
         scale: 0.001
@@ -634,7 +634,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_3_voltage:
         register: 34220
         scale: 0.001
@@ -644,7 +644,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_4_voltage:
         register: 34221
         scale: 0.001
@@ -654,7 +654,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_5_voltage:
         register: 34222
         scale: 0.001
@@ -664,7 +664,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_6_voltage:
         register: 34223
         scale: 0.001
@@ -674,7 +674,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_7_voltage:
         register: 34224
         scale: 0.001
@@ -684,7 +684,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_8_voltage:
         register: 34225
         scale: 0.001
@@ -694,7 +694,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_9_voltage:
         register: 34226
         scale: 0.001
@@ -704,7 +704,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_10_voltage:
         register: 34227
         scale: 0.001
@@ -714,7 +714,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_11_voltage:
         register: 34228
         scale: 0.001
@@ -724,7 +724,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_12_voltage:
         register: 34229
         scale: 0.001
@@ -734,7 +734,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_3_cell_13_voltage:
         register: 34230
         scale: 0.001
@@ -744,7 +744,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_1_voltage:
         register: 34318
         scale: 0.001
@@ -754,7 +754,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_2_voltage:
         register: 34319
         scale: 0.001
@@ -764,7 +764,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_3_voltage:
         register: 34320
         scale: 0.001
@@ -774,7 +774,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_4_voltage:
         register: 34321
         scale: 0.001
@@ -784,7 +784,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_5_voltage:
         register: 34322
         scale: 0.001
@@ -794,7 +794,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_6_voltage:
         register: 34323
         scale: 0.001
@@ -804,7 +804,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_7_voltage:
         register: 34324
         scale: 0.001
@@ -814,7 +814,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_8_voltage:
         register: 34325
         scale: 0.001
@@ -824,7 +824,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_9_voltage:
         register: 34326
         scale: 0.001
@@ -834,7 +834,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_10_voltage:
         register: 34327
         scale: 0.001
@@ -844,7 +844,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_11_voltage:
         register: 34328
         scale: 0.001
@@ -854,7 +854,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_12_voltage:
         register: 34329
         scale: 0.001
@@ -864,7 +864,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_4_cell_13_voltage:
         register: 34330
         scale: 0.001
@@ -874,7 +874,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_1_voltage:
         register: 34418
         scale: 0.001
@@ -884,7 +884,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_2_voltage:
         register: 34419
         scale: 0.001
@@ -894,7 +894,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_3_voltage:
         register: 34420
         scale: 0.001
@@ -904,7 +904,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_4_voltage:
         register: 34421
         scale: 0.001
@@ -914,7 +914,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_5_voltage:
         register: 34422
         scale: 0.001
@@ -924,7 +924,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_6_voltage:
         register: 34423
         scale: 0.001
@@ -934,7 +934,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_7_voltage:
         register: 34424
         scale: 0.001
@@ -944,7 +944,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_8_voltage:
         register: 34425
         scale: 0.001
@@ -954,7 +954,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_9_voltage:
         register: 34426
         scale: 0.001
@@ -964,7 +964,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_10_voltage:
         register: 34427
         scale: 0.001
@@ -974,7 +974,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_11_voltage:
         register: 34428
         scale: 0.001
@@ -984,7 +984,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_12_voltage:
         register: 34429
         scale: 0.001
@@ -994,7 +994,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_5_cell_13_voltage:
         register: 34430
         scale: 0.001
@@ -1004,7 +1004,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_1_voltage:
         register: 34518
         scale: 0.001
@@ -1014,7 +1014,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_2_voltage:
         register: 34519
         scale: 0.001
@@ -1024,7 +1024,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_3_voltage:
         register: 34520
         scale: 0.001
@@ -1034,7 +1034,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_4_voltage:
         register: 34521
         scale: 0.001
@@ -1044,7 +1044,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_5_voltage:
         register: 34522
         scale: 0.001
@@ -1054,7 +1054,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_6_voltage:
         register: 34523
         scale: 0.001
@@ -1064,7 +1064,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_7_voltage:
         register: 34524
         scale: 0.001
@@ -1074,7 +1074,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_8_voltage:
         register: 34525
         scale: 0.001
@@ -1084,7 +1084,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_9_voltage:
         register: 34526
         scale: 0.001
@@ -1094,7 +1094,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_10_voltage:
         register: 34527
         scale: 0.001
@@ -1104,7 +1104,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_11_voltage:
         register: 34528
         scale: 0.001
@@ -1114,7 +1114,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_12_voltage:
         register: 34529
         scale: 0.001
@@ -1124,7 +1124,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_6_cell_13_voltage:
         register: 34530
         scale: 0.001
@@ -1134,7 +1134,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     inverter_state:
         register: 35100
         scale: 1
@@ -1155,7 +1155,7 @@ SENSOR_DEFINITIONS:
         data_type: uint16
         icon: "mdi:home-automation"
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -1165,7 +1165,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_current:
         register: 32301
         scale: 0.01
@@ -1175,7 +1175,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_power:
         register: 32302
         count: 2
@@ -1197,7 +1197,7 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         precision: 0
-        scan_interval: medium
+        scan_interval: high
     mppt1_voltage:
         register: 30020
         scale: 0.1
@@ -1207,7 +1207,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt1_current:
         register: 30024
         scale: 0.1
@@ -1217,7 +1217,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt1_power:
         register: 30037
         scale: 0.1
@@ -1237,7 +1237,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt2_current:
         register: 30025
         scale: 0.1
@@ -1247,7 +1247,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt2_power:
         register: 30038
         scale: 0.1
@@ -1267,7 +1267,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt3_current:
         register: 30026
         scale: 0.1
@@ -1277,7 +1277,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt3_power:
         register: 30039
         scale: 0.1
@@ -1297,7 +1297,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt4_current:
         register: 30027
         scale: 0.1
@@ -1307,7 +1307,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt4_power:
         register: 30040
         scale: 0.1
@@ -1324,7 +1324,7 @@ SENSOR_DEFINITIONS:
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:
@@ -1334,7 +1334,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:check-network-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
     cloud_status:
         register: 30302
         data_type: uint16
@@ -1342,7 +1342,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:cloud-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 SELECT_DEFINITIONS:
     user_work_mode:
@@ -1364,7 +1364,7 @@ SELECT_DEFINITIONS:
     schedule_1_days:
         register: 43100
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -1377,7 +1377,7 @@ SELECT_DEFINITIONS:
     schedule_2_days:
         register: 43105
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -1390,7 +1390,7 @@ SELECT_DEFINITIONS:
     schedule_3_days:
         register: 43110
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -1403,7 +1403,7 @@ SELECT_DEFINITIONS:
     schedule_4_days:
         register: 43115
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -1416,7 +1416,7 @@ SELECT_DEFINITIONS:
     schedule_5_days:
         register: 43120
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -1429,7 +1429,7 @@ SELECT_DEFINITIONS:
     schedule_6_days:
         register: 43125
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -1463,7 +1463,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_enabled:
         register: 43109
         command_on: 1
@@ -1472,7 +1472,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_enabled:
         register: 43114
         command_on: 1
@@ -1481,7 +1481,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_enabled:
         register: 43119
         command_on: 1
@@ -1490,7 +1490,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_enabled:
         register: 43124
         command_on: 1
@@ -1499,7 +1499,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_enabled:
         register: 43129
         command_on: 1
@@ -1508,7 +1508,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 NUMBER_DEFINITIONS:
     set_charge_power:
@@ -1572,7 +1572,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_start:
         register: 43106
         enabled_by_default: false
@@ -1583,7 +1583,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_start:
         register: 43111
         enabled_by_default: false
@@ -1594,7 +1594,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_start:
         register: 43116
         enabled_by_default: false
@@ -1605,7 +1605,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_start:
         register: 43121
         enabled_by_default: false
@@ -1616,7 +1616,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_start:
         register: 43126
         enabled_by_default: false
@@ -1627,7 +1627,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_end:
         register: 43102
         enabled_by_default: false
@@ -1638,7 +1638,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_end:
         register: 43107
         enabled_by_default: false
@@ -1649,7 +1649,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_end:
         register: 43112
         enabled_by_default: false
@@ -1660,7 +1660,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_end:
         register: 43117
         enabled_by_default: false
@@ -1671,7 +1671,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_end:
         register: 43122
         enabled_by_default: false
@@ -1682,7 +1682,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_end:
         register: 43127
         enabled_by_default: false
@@ -1693,7 +1693,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_mode:
         register: 43103
         enabled_by_default: false
@@ -1704,7 +1704,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_mode:
         register: 43108
         enabled_by_default: false
@@ -1715,7 +1715,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_mode:
         register: 43113
         enabled_by_default: false
@@ -1726,7 +1726,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_mode:
         register: 43118
         enabled_by_default: false
@@ -1737,7 +1737,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_mode:
         register: 43123
         enabled_by_default: false
@@ -1748,7 +1748,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_mode:
         register: 43128
         enabled_by_default: false
@@ -1759,7 +1759,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 BUTTON_DEFINITIONS:
     reset_device:

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -31,21 +31,21 @@ SENSOR_DEFINITIONS:
         data_type: char
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
-        scan_interval: very_low
+        scan_interval: low
     bms_version:
         register: 30204
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     vms_version:
         register: 30202
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     ems_version:
         register: 30200
         category: diagnostic
@@ -53,7 +53,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        scan_interval: very_low
+        scan_interval: low
     comm_module_firmware:
         register: 30350
         count: 6
@@ -61,14 +61,14 @@ SENSOR_DEFINITIONS:
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     mac_address:
         register: 30304
         count: 6
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     battery_soc:
         register: 32104
         scale: 1
@@ -78,7 +78,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_total_energy:
         register: 32105
         scale: 0.001
@@ -98,7 +98,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_current:
         register: 30101
         scale: 0.1
@@ -108,7 +108,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_power:
         register: 30001
         count: 1
@@ -129,7 +129,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos1_temperature:
         register: 35001
         scale: 0.1
@@ -139,7 +139,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos2_temperature:
         register: 35002
         scale: 0.1
@@ -149,7 +149,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     ac_voltage:
         register: 32200
         scale: 0.1
@@ -159,7 +159,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_current:
         register: 37004
         scale: 0.004
@@ -169,7 +169,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_power:
         register: 30006
         count: 1
@@ -190,7 +190,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     total_charging_energy:
         register: 33000
         count: 2
@@ -276,7 +276,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     min_cell_temperature:
         register: 35011
         scale: 0.1
@@ -286,7 +286,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     max_cell_voltage:
         register: 37007
         scale: 0.001
@@ -296,7 +296,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     min_cell_voltage:
         register: 37008
         scale: 0.001
@@ -306,7 +306,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_1_voltage:
         register: 34018
         scale: 0.001
@@ -316,7 +316,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_2_voltage:
         register: 34019
         scale: 0.001
@@ -326,7 +326,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_3_voltage:
         register: 34020
         scale: 0.001
@@ -336,7 +336,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_4_voltage:
         register: 34021
         scale: 0.001
@@ -346,7 +346,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_5_voltage:
         register: 34022
         scale: 0.001
@@ -356,7 +356,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_6_voltage:
         register: 34023
         scale: 0.001
@@ -366,7 +366,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_7_voltage:
         register: 34024
         scale: 0.001
@@ -376,7 +376,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_8_voltage:
         register: 34025
         scale: 0.001
@@ -386,7 +386,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_9_voltage:
         register: 34026
         scale: 0.001
@@ -396,7 +396,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_10_voltage:
         register: 34027
         scale: 0.001
@@ -406,7 +406,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_11_voltage:
         register: 34028
         scale: 0.001
@@ -416,7 +416,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_12_voltage:
         register: 34029
         scale: 0.001
@@ -426,7 +426,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_13_voltage:
         register: 34030
         scale: 0.001
@@ -436,7 +436,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_14_voltage:
         register: 34031
         scale: 0.001
@@ -446,7 +446,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_15_voltage:
         register: 34032
         scale: 0.001
@@ -456,7 +456,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_16_voltage:
         register: 34033
         scale: 0.001
@@ -466,7 +466,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     inverter_state:
         register: 35100
         scale: 1
@@ -487,7 +487,7 @@ SENSOR_DEFINITIONS:
         data_type: uint16
         icon: "mdi:home-automation"
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -497,7 +497,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_current:
         register: 32301
         scale: 0.01
@@ -507,7 +507,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_power:
         register: 32302
         count: 2
@@ -529,7 +529,7 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         precision: 0
-        scan_interval: medium
+        scan_interval: high
     mppt1_voltage:
         register: 30020
         scale: 0.1
@@ -539,7 +539,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt1_current:
         register: 30024
         scale: 0.1
@@ -549,7 +549,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt1_power:
         register: 30037
         scale: 0.1
@@ -569,7 +569,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt2_current:
         register: 30025
         scale: 0.1
@@ -579,7 +579,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt2_power:
         register: 30038
         scale: 0.1
@@ -599,7 +599,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt3_current:
         register: 30026
         scale: 0.1
@@ -609,7 +609,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt3_power:
         register: 30039
         scale: 0.1
@@ -629,7 +629,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt4_current:
         register: 30027
         scale: 0.1
@@ -639,7 +639,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     mppt4_power:
         register: 30040
         scale: 0.1
@@ -656,7 +656,7 @@ SENSOR_DEFINITIONS:
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:
@@ -666,7 +666,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:check-network-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
     cloud_status:
         register: 30302
         data_type: uint16
@@ -674,7 +674,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:cloud-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 SELECT_DEFINITIONS:
     user_work_mode:
@@ -722,7 +722,7 @@ SELECT_DEFINITIONS:
     schedule_3_days:
         register: 43110
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -735,7 +735,7 @@ SELECT_DEFINITIONS:
     schedule_4_days:
         register: 43115
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -748,7 +748,7 @@ SELECT_DEFINITIONS:
     schedule_5_days:
         register: 43120
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -761,7 +761,7 @@ SELECT_DEFINITIONS:
     schedule_6_days:
         register: 43125
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -813,7 +813,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_enabled:
         register: 43119
         command_on: 1
@@ -822,7 +822,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_enabled:
         register: 43124
         command_on: 1
@@ -831,7 +831,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_enabled:
         register: 43129
         command_on: 1
@@ -840,7 +840,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 NUMBER_DEFINITIONS:
     set_charge_power:
@@ -927,7 +927,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_start:
         register: 43116
         enabled_by_default: false
@@ -938,7 +938,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_start:
         register: 43121
         enabled_by_default: false
@@ -949,7 +949,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_start:
         register: 43126
         enabled_by_default: false
@@ -960,7 +960,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_end:
         register: 43102
         enabled_by_default: false
@@ -993,7 +993,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_end:
         register: 43117
         enabled_by_default: false
@@ -1004,7 +1004,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_end:
         register: 43122
         enabled_by_default: false
@@ -1015,7 +1015,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_end:
         register: 43127
         enabled_by_default: false
@@ -1026,7 +1026,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_mode:
         register: 43103
         enabled_by_default: false
@@ -1059,7 +1059,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_mode:
         register: 43118
         enabled_by_default: false
@@ -1070,7 +1070,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_mode:
         register: 43123
         enabled_by_default: false
@@ -1081,7 +1081,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_mode:
         register: 43128
         enabled_by_default: false
@@ -1092,7 +1092,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 BUTTON_DEFINITIONS:
     reset_device:

--- a/custom_components/marstek_modbus/registers/e_v12.yaml
+++ b/custom_components/marstek_modbus/registers/e_v12.yaml
@@ -16,13 +16,13 @@ SENSOR_DEFINITIONS:
         data_type: char
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
-        scan_interval: very_low
+        scan_interval: low
     sn_code:
         register: 31200
         count: 10
         data_type: char
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
     software_version:
         register: 31100
         scale: 0.01
@@ -30,14 +30,14 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     bms_version:
         register: 31102
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     ems_version:
         register: 31101
         category: diagnostic
@@ -45,7 +45,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        scan_interval: very_low
+        scan_interval: low
     comm_module_firmware:
         register: 30800
         count: 6
@@ -53,14 +53,14 @@ SENSOR_DEFINITIONS:
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     mac_address:
         register: 30402
         count: 6
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     battery_soc:
         register: 32104
         scale: 1
@@ -70,7 +70,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_total_energy:
         register: 32105
         scale: 0.001
@@ -90,7 +90,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_current:
         register: 32101
         scale: 0.01
@@ -100,7 +100,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_power:
         register: 32102
         count: 2
@@ -121,7 +121,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos1_temperature:
         register: 35001
         scale: 0.1
@@ -131,7 +131,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos2_temperature:
         register: 35002
         scale: 0.1
@@ -141,7 +141,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     ac_voltage:
         register: 32200
         scale: 0.1
@@ -151,7 +151,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_current:
         register: 32201
         scale: 0.01
@@ -161,7 +161,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_power:
         register: 32202
         count: 2
@@ -182,7 +182,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     total_charging_energy:
         register: 33000
         count: 2
@@ -258,7 +258,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     min_cell_temperature:
         register: 35011
         scale: 1
@@ -268,7 +268,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     max_cell_voltage:
         register: 37007
         scale: 0.001
@@ -278,7 +278,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     min_cell_voltage:
         register: 37008
         scale: 0.001
@@ -288,7 +288,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     inverter_state:
         register: 35100
         scale: 1
@@ -368,7 +368,7 @@ SENSOR_DEFINITIONS:
         data_type: uint16
         icon: "mdi:home-automation"
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -378,7 +378,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_current:
         register: 32301
         scale: 0.01
@@ -388,7 +388,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_power:
         register: 32302
         count: 2
@@ -410,14 +410,14 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         precision: 0
-        scan_interval: medium
+        scan_interval: high
     bluetooth_status:
         register: 30301
         data_type: uint16
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:
@@ -427,7 +427,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:check-network-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
     cloud_status:
         register: 30302
         data_type: uint16
@@ -435,13 +435,13 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:cloud-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
     discharge_limit_mode:
         register: 41010
         data_type: uint16
         icon: "mdi:battery-arrow-down-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 SELECT_DEFINITIONS:
     user_work_mode:
@@ -478,7 +478,7 @@ SELECT_DEFINITIONS:
     schedule_1_days:
         register: 43100
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -491,7 +491,7 @@ SELECT_DEFINITIONS:
     schedule_2_days:
         register: 43105
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -504,7 +504,7 @@ SELECT_DEFINITIONS:
     schedule_3_days:
         register: 43110
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -517,7 +517,7 @@ SELECT_DEFINITIONS:
     schedule_4_days:
         register: 43115
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -530,7 +530,7 @@ SELECT_DEFINITIONS:
     schedule_5_days:
         register: 43120
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -543,7 +543,7 @@ SELECT_DEFINITIONS:
     schedule_6_days:
         register: 43125
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -577,7 +577,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_enabled:
         register: 43109
         command_on: 1
@@ -586,7 +586,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_enabled:
         register: 43114
         command_on: 1
@@ -595,7 +595,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_enabled:
         register: 43119
         command_on: 1
@@ -604,7 +604,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_enabled:
         register: 43124
         command_on: 1
@@ -613,7 +613,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_enabled:
         register: 43129
         command_on: 1
@@ -622,7 +622,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 NUMBER_DEFINITIONS:
     set_charge_power:
@@ -708,7 +708,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_start:
         register: 43106
         enabled_by_default: false
@@ -719,7 +719,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_start:
         register: 43111
         enabled_by_default: false
@@ -730,7 +730,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_start:
         register: 43116
         enabled_by_default: false
@@ -741,7 +741,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_start:
         register: 43121
         enabled_by_default: false
@@ -752,7 +752,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_start:
         register: 43126
         enabled_by_default: false
@@ -763,7 +763,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_end:
         register: 43102
         enabled_by_default: false
@@ -774,7 +774,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_end:
         register: 43107
         enabled_by_default: false
@@ -785,7 +785,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_end:
         register: 43112
         enabled_by_default: false
@@ -796,7 +796,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_end:
         register: 43117
         enabled_by_default: false
@@ -807,7 +807,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_end:
         register: 43122
         enabled_by_default: false
@@ -818,7 +818,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_end:
         register: 43127
         enabled_by_default: false
@@ -829,7 +829,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_mode:
         register: 43103
         enabled_by_default: false
@@ -840,7 +840,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_2_mode:
         register: 43108
         enabled_by_default: false
@@ -851,7 +851,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_3_mode:
         register: 43113
         enabled_by_default: false
@@ -862,7 +862,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_mode:
         register: 43118
         enabled_by_default: false
@@ -873,7 +873,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_mode:
         register: 43123
         enabled_by_default: false
@@ -884,7 +884,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_mode:
         register: 43128
         enabled_by_default: false
@@ -895,7 +895,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 BUTTON_DEFINITIONS:
     reset_device:

--- a/custom_components/marstek_modbus/registers/e_v3.yaml
+++ b/custom_components/marstek_modbus/registers/e_v3.yaml
@@ -23,21 +23,21 @@ SENSOR_DEFINITIONS:
         data_type: char
         enabled_by_default: true
         icon: "mdi:package-variant-closed"
-        scan_interval: very_low
+        scan_interval: low
     bms_version:
         register: 30204
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     vms_version:
         register: 30202
         icon: "mdi:battery-check-outline"
         category: diagnostic
         enabled_by_default: true
         data_type: uint16
-        scan_interval: very_low
+        scan_interval: low
     ems_version:
         register: 30200
         category: diagnostic
@@ -45,7 +45,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         scale: 1
-        scan_interval: very_low
+        scan_interval: low
     comm_module_firmware:
         register: 30350
         count: 6
@@ -53,14 +53,14 @@ SENSOR_DEFINITIONS:
         icon: "mdi:ticket-confirmation-outline"
         enabled_by_default: true
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     mac_address:
         register: 30304
         count: 6
         enabled_by_default: true
         icon: "mdi:ethernet"
         data_type: char
-        scan_interval: very_low
+        scan_interval: low
     battery_soc:
         register: 34002
         scale: 0.1
@@ -70,7 +70,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     battery_total_energy:
         register: 32105
         scale: 0.001
@@ -90,7 +90,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     battery_current:
         register: 30101
         scale: 0.1
@@ -100,7 +100,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     battery_power:
         register: 30001
         count: 1
@@ -121,7 +121,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos1_temperature:
         register: 35001
         scale: 0.1
@@ -131,7 +131,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     internal_mos2_temperature:
         register: 35002
         scale: 0.1
@@ -141,7 +141,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     ac_voltage:
         register: 32200
         scale: 0.1
@@ -151,7 +151,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_current:
         register: 37004
         scale: 0.004
@@ -161,7 +161,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_power:
         register: 30006
         count: 1
@@ -182,7 +182,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: true
         data_type: int16
         precision: 2
-        scan_interval: medium
+        scan_interval: high
     total_charging_energy:
         register: 33000
         count: 2
@@ -268,7 +268,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     min_cell_temperature:
         register: 35011
         scale: 0.1
@@ -278,7 +278,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     max_cell_voltage:
         register: 37007
         scale: 0.001
@@ -288,7 +288,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     min_cell_voltage:
         register: 37008
         scale: 0.001
@@ -298,7 +298,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_1_voltage:
         register: 34018
         scale: 0.001
@@ -308,7 +308,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_2_voltage:
         register: 34019
         scale: 0.001
@@ -318,7 +318,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_3_voltage:
         register: 34020
         scale: 0.001
@@ -328,7 +328,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_4_voltage:
         register: 34021
         scale: 0.001
@@ -338,7 +338,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_5_voltage:
         register: 34022
         scale: 0.001
@@ -348,7 +348,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_6_voltage:
         register: 34023
         scale: 0.001
@@ -358,7 +358,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_7_voltage:
         register: 34024
         scale: 0.001
@@ -368,7 +368,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_8_voltage:
         register: 34025
         scale: 0.001
@@ -378,7 +378,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_9_voltage:
         register: 34026
         scale: 0.001
@@ -388,7 +388,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_10_voltage:
         register: 34027
         scale: 0.001
@@ -398,7 +398,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_11_voltage:
         register: 34028
         scale: 0.001
@@ -408,7 +408,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_12_voltage:
         register: 34029
         scale: 0.001
@@ -418,7 +418,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_13_voltage:
         register: 34030
         scale: 0.001
@@ -428,7 +428,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_14_voltage:
         register: 34031
         scale: 0.001
@@ -438,7 +438,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_15_voltage:
         register: 34032
         scale: 0.001
@@ -448,7 +448,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     battery_1_cell_16_voltage:
         register: 34033
         scale: 0.001
@@ -458,7 +458,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: int16
         precision: 3
-        scan_interval: medium
+        scan_interval: high
     inverter_state:
         register: 35100
         scale: 1
@@ -479,7 +479,7 @@ SENSOR_DEFINITIONS:
         data_type: uint16
         icon: "mdi:home-automation"
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
     ac_offgrid_voltage:
         register: 32300
         scale: 0.1
@@ -489,7 +489,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_current:
         register: 32301
         scale: 0.01
@@ -499,7 +499,7 @@ SENSOR_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         precision: 1
-        scan_interval: medium
+        scan_interval: high
     ac_offgrid_power:
         register: 32302
         count: 1
@@ -521,14 +521,14 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         precision: 0
-        scan_interval: medium
+        scan_interval: high
     bluetooth_status:
         register: 30301
         data_type: uint16
         icon: "mdi:bluetooth"
         category: diagnostic
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:
@@ -538,7 +538,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:check-network-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
     cloud_status:
         register: 30302
         data_type: uint16
@@ -546,7 +546,7 @@ BINARY_SENSOR_DEFINITIONS:
         device_class: connectivity
         icon: "mdi:cloud-outline"
         enabled_by_default: false
-        scan_interval: medium
+        scan_interval: high
 
 SELECT_DEFINITIONS:
     user_work_mode:
@@ -594,7 +594,7 @@ SELECT_DEFINITIONS:
     schedule_3_days:
         register: 43110
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -607,7 +607,7 @@ SELECT_DEFINITIONS:
     schedule_4_days:
         register: 43115
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -620,7 +620,7 @@ SELECT_DEFINITIONS:
     schedule_5_days:
         register: 43120
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -633,7 +633,7 @@ SELECT_DEFINITIONS:
     schedule_6_days:
         register: 43125
         enabled_by_default: false
-        scan_interval: very_low
+        scan_interval: low
         category: config
         options:
             sunday: 64
@@ -685,7 +685,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_enabled:
         register: 43119
         command_on: 1
@@ -694,7 +694,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_enabled:
         register: 43124
         command_on: 1
@@ -703,7 +703,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_enabled:
         register: 43129
         command_on: 1
@@ -712,7 +712,7 @@ SWITCH_DEFINITIONS:
         enabled_by_default: false
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 NUMBER_DEFINITIONS:
     set_charge_power:
@@ -798,7 +798,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_start:
         register: 43116
         enabled_by_default: false
@@ -809,7 +809,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_start:
         register: 43121
         enabled_by_default: false
@@ -820,7 +820,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_start:
         register: 43126
         enabled_by_default: false
@@ -831,7 +831,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_end:
         register: 43102
         enabled_by_default: false
@@ -864,7 +864,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_end:
         register: 43117
         enabled_by_default: false
@@ -875,7 +875,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_end:
         register: 43122
         enabled_by_default: false
@@ -886,7 +886,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_end:
         register: 43127
         enabled_by_default: false
@@ -897,7 +897,7 @@ NUMBER_DEFINITIONS:
         unit: "min"
         data_type: uint16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_1_mode:
         register: 43103
         enabled_by_default: false
@@ -930,7 +930,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_4_mode:
         register: 43118
         enabled_by_default: false
@@ -941,7 +941,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_5_mode:
         register: 43123
         enabled_by_default: false
@@ -952,7 +952,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
     schedule_6_mode:
         register: 43128
         enabled_by_default: false
@@ -963,7 +963,7 @@ NUMBER_DEFINITIONS:
         unit: W
         data_type: int16
         category: config
-        scan_interval: very_low
+        scan_interval: low
 
 BUTTON_DEFINITIONS:
     reset_device:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -47,9 +47,7 @@
         "description": "Abfragehäufigkeit pro Kategorie anpassen",
         "data": {
           "high": "High-Priorität Intervall (s)",
-          "medium": "Medium-Priorität Intervall (s)",
-          "low": "Low-Priorität Intervall (s)",
-          "very_low": "Very-low-Priorität Intervall (s)"
+          "low": "Low-Priorität Intervall (s)"
         }
       },
       "connection": {

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -47,9 +47,7 @@
         "description": "Adjust polling frequency per category",
         "data": {
           "high": "High priority interval (s)",
-          "medium": "Medium priority interval (s)",
-          "low": "Low priority interval (s)",
-          "very_low": "Very low priority interval (s)"
+          "low": "Low priority interval (s)"
         }
       },
       "connection": {

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -47,15 +47,11 @@
         "description": "Pas de pollingfrequentie per categorie aan",
         "data": {
           "high": "High-prioriteit interval (s)",
-          "medium": "Medium-prioriteit interval (s)",
-          "low": "Low-prioriteit interval (s)",
-          "very_low": "Very-low-prioriteit interval (s)"
+          "low": "Low-prioriteit interval (s)"
         },
         "data_description": {
           "high": "Interval voor sensoren met hoge prioriteit",
-          "medium": "Interval voor sensoren met gemiddelde prioriteit",
-          "low": "Interval voor sensoren met lage prioriteit",
-          "very_low": "Interval voor sensoren met zeer lage prioriteit"
+          "low": "Interval voor sensoren met lage prioriteit"
         }
       },
       "connection": {


### PR DESCRIPTION
## Summary
- read contiguous due registers as smart Modbus blocks and decode per entity from a shared response
- trim block reads to the currently due sensors, add clearer block/single/failover diagnostics, and keep single-read fallback behavior
- reduce polling configuration from `high`/`medium`/`low`/`very_low` to `high`/`low` with legacy option migration
- update register definitions and translations to match the new polling model
- keep coordinator updates resilient when `total_increasing` values regress unexpectedly and guard number writes when coordinator data is still empty

## Validation
- checked editor diagnostics for the updated Python files: no errors found
- validated behavior against Home Assistant logs during runtime
- observed polling summaries such as `due=54, requests=27` and `due=15, requests=9`, showing fewer Modbus requests during full and fast cycles
- no automated test suite was run in this workspace

## Notes
- This PR addresses the smart polling work for #237
- The branch also contains the coordinator resilience fix that avoids hard failures on unexpected `total_increasing` regressions