### PR TITLE
Add Modbus connection health binary sensor with diagnostic attributes

### DIFF
--- a/custom_components/marstek_modbus/binary_sensor.py
+++ b/custom_components/marstek_modbus/binary_sensor.py
@@ -7,7 +7,7 @@ All entities are registered through the coordinator to enable centralized pollin
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -39,6 +39,7 @@ async def async_setup_entry(
     # Retrieve the coordinator instance from hass data and add entities
     coordinator = hass.data[DOMAIN][entry.entry_id]
     entities = [MarstekBinarySensor(coordinator, definition) for definition in coordinator.BINARY_SENSOR_DEFINITIONS]
+    entities.append(MarstekConnectionBinarySensor(coordinator))
     async_add_entities(entities)   
 
 
@@ -121,6 +122,45 @@ class MarstekBinarySensor(CoordinatorEntity, BinarySensorEntity):
         Return device information for Home Assistant's device registry.
         Includes identifiers, name, manufacturer, model, and entry type.
         """
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
+            "name": self.coordinator.config_entry.title,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL,
+            "entry_type": "service",
+        }
+
+
+class MarstekConnectionBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Diagnostic binary sensor exposing Modbus connection health."""
+
+    def __init__(self, coordinator: MarstekCoordinator):
+        """Initialize the Modbus connection binary sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_modbus_connection"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "modbus_connection"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    @property
+    def available(self) -> bool:
+        """Always expose the connection entity so health changes stay visible."""
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the Modbus connection is currently healthy."""
+        return self.coordinator.is_connection_healthy()
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return diagnostic connection health attributes."""
+        return self.coordinator.get_connection_health_attributes()
+
+    @property
+    def device_info(self) -> dict:
+        """Return device information for Home Assistant's device registry."""
         return {
             "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
             "name": self.coordinator.config_entry.title,

--- a/custom_components/marstek_modbus/coordinator.py
+++ b/custom_components/marstek_modbus/coordinator.py
@@ -107,6 +107,13 @@ class MarstekCoordinator(DataUpdateCoordinator):
         # Connection health tracking for diagnostics
         self._last_successful_read = None
         self._connection_established_at = None
+        self._last_cycle_stats = {
+            "attempted_reads": 0,
+            "successful_reads": 0,
+            "timeout_reads": 0,
+            "degraded": False,
+            "last_cycle_at": None,
+        }
 
         # Per-register failure tracking for exponential backoff.
         # Counts consecutive failed reads per key; resets to 0 on first success.
@@ -204,6 +211,54 @@ class MarstekCoordinator(DataUpdateCoordinator):
             diagnostics["suspension_expires_in_seconds"] = (self._suspension_reset_time - now).total_seconds()
         
         return diagnostics
+
+    def get_connection_health_threshold_seconds(self) -> int:
+        """Return the stale threshold used for the connection health entity."""
+        min_interval = min(self.scan_intervals.values()) if self.scan_intervals else 30
+        return max(int(min_interval) * 3, 60)
+
+    def is_connection_healthy(self) -> bool:
+        """Return True when Modbus communication is considered healthy."""
+        from homeassistant.util.dt import utcnow
+
+        if self._connection_suspended or self._last_successful_read is None:
+            return False
+
+        age_seconds = (utcnow() - self._last_successful_read).total_seconds()
+        return age_seconds <= self.get_connection_health_threshold_seconds()
+
+    def is_connection_degraded(self) -> bool:
+        """Return True when communication still works but recent polling was partial."""
+        stats = self._last_cycle_stats or {}
+        attempted_reads = int(stats.get("attempted_reads", 0) or 0)
+        successful_reads = int(stats.get("successful_reads", 0) or 0)
+        timeout_reads = int(stats.get("timeout_reads", 0) or 0)
+
+        return successful_reads > 0 and (
+            successful_reads < attempted_reads
+            or timeout_reads > 0
+            or self._consecutive_timeout_cycles > 0
+        )
+
+    def get_connection_health_attributes(self) -> dict:
+        """Return diagnostic state attributes for the Modbus connection entity."""
+        stats = self._last_cycle_stats or {}
+        health = "offline"
+        if self.is_connection_healthy():
+            health = "degraded" if self.is_connection_degraded() else "ok"
+
+        return {
+            "health": health,
+            "degraded": self.is_connection_degraded(),
+            "last_successful_read": self._last_successful_read.isoformat() if self._last_successful_read else None,
+            "attempted_reads": int(stats.get("attempted_reads", 0) or 0),
+            "successful_reads": int(stats.get("successful_reads", 0) or 0),
+            "timeout_reads": int(stats.get("timeout_reads", 0) or 0),
+            "consecutive_failures": self._consecutive_failures,
+            "consecutive_timeout_cycles": self._consecutive_timeout_cycles,
+            "connection_suspended": self._connection_suspended,
+            "stale_after_seconds": self.get_connection_health_threshold_seconds(),
+        }
 
     async def async_init(self):
         """Asynchronously initialize the Modbus connection."""
@@ -668,6 +723,10 @@ class MarstekCoordinator(DataUpdateCoordinator):
                         entity_type, key, new_failures,
                     )
 
+        degraded = successful_reads > 0 and (
+            successful_reads < attempted_reads or self._timeouts_in_cycle > 0
+        )
+
         # Connection retry logic: only track failures if we actually attempted reads
         if attempted_reads > 0:
             timeout_reads = int(getattr(self, "_timeouts_in_cycle", 0) or 0)
@@ -740,6 +799,14 @@ class MarstekCoordinator(DataUpdateCoordinator):
                 self._consecutive_timeout_cycles = 0
         else:
             _LOGGER.debug("No sensors due for update in this cycle")
+
+        self._last_cycle_stats = {
+            "attempted_reads": attempted_reads,
+            "successful_reads": successful_reads,
+            "timeout_reads": int(getattr(self, "_timeouts_in_cycle", 0) or 0),
+            "degraded": degraded,
+            "last_cycle_at": now,
+        }
 
         # Defensive check
         if self.data is None:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -512,6 +512,9 @@
       }
     },
     "binary_sensor": {
+      "modbus_connection": {
+        "name": "Modbus-Verbindung"
+      },
       "wifi_status": {
         "name": "WLAN-Status"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -516,6 +516,9 @@
       }
     },
     "binary_sensor": {
+      "modbus_connection": {
+        "name": "Modbus Connection"
+      },
       "wifi_status": {
         "name": "WiFi Status" 
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -521,6 +521,9 @@
       }
     },
     "binary_sensor": {
+      "modbus_connection": {
+        "name": "Modbus-verbinding"
+      },
       "wifi_status": {
         "name": "WiFi-status"
       },


### PR DESCRIPTION
## Summary
- Add a new diagnostic connectivity binary sensor: `modbus_connection`
- Expose connection health directly from the coordinator
- Include rich diagnostic attributes for troubleshooting and automations
- Add translations for the new entity in English, Dutch, and German

## What was added
- New binary sensor entity with `device_class: connectivity`
- Coordinator health helpers:
  - stale threshold calculation
  - healthy/degraded evaluation
  - attribute payload builder
- Per-cycle polling stats stored for health attributes

## Attribute meanings (English)
- `health`: Overall health state (`ok`, `degraded`, `offline`)
- `degraded`: `true` when communication still works but quality is reduced (partial reads, timeouts, or timeout pressure)
- `last_successful_read`: UTC timestamp of the last successful Modbus read
- `attempted_reads`: Number of register reads attempted in the latest polling cycle
- `successful_reads`: Number of successful reads in the latest polling cycle
- `timeout_reads`: Number of reads that timed out in the latest polling cycle
- `consecutive_failures`: Number of consecutive cycles where all attempted reads failed
- `consecutive_timeout_cycles`: Number of consecutive cycles with a high timeout ratio
- `connection_suspended`: `true` when retries are temporarily paused after repeated full failures
- `stale_after_seconds`: Age threshold used to mark the connection as unhealthy when no successful reads occur

## Behavior
- Binary sensor `on`: connection is healthy (recent successful reads, not suspended)
- Binary sensor `off`: communication is stale or suspended/offline

## Validation
- Local static error check on changed Python files reported no issues.