### PR TITLE
Add Venus D per-pack and status registers verified on hardware

### DIFF
--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -54,3 +54,67 @@ Hardware tested: Marstek Venus E v3, firmware V148.
 | 45604 | Unknown. Value 20599 (0x5077). Adjacent to 45603/45605. Possibly WiFi channel, frequency, or AP info. Not confirmed. |
 | 45605 | Unknown. Constant value 74 in V148 scan. Adjacent to 45603/45604. |
 | 47400 | Unknown. Value 43707 (0xAABB) in V148 scan. Alternating-nibble sentinel — same class as 0x9999, likely "not configured" / undefined. |
+
+---
+
+## Venus D (d.yaml)
+
+Hardware tested: Marstek Venus D, multi-pack setup (verified with up to 6 packs installed;
+address pattern extends to a 7th pack). BMS firmware observed going 116 → 1177 (v117.7) after a BMS update.
+All registers below were read back and cross-checked on real hardware, but are **not** added to the
+integration — following the same policy applied to Venus A/E, which integrates only per-pack SoC and
+per-pack cell voltages, not the remaining per-pack scalars.
+
+Integrated in this PR (for reference): `battery_soc_1..6` (34002/34102/34202/34302/34402/34502),
+`battery_2/3/4_cell_1..16_voltage` (34118–34133 / 34218–34233 / 34318–34333, 16 cells per pack —
+Venus D packs carry 16 cells vs. 13 on Venus A), `alarm_status` (36000), `fault_status` (36100).
+
+### Mirrors / inferior duplicates of already-integrated sensors
+
+| Register | Notes |
+|----------|-------|
+| 30002 | Mirror of `internal_temperature` (35000). int16, scale 0.1 °C. |
+| 30003 | Mirror of `internal_mos1_temperature` (35001). int16, scale 0.1 °C. |
+| 30004 | Mirror of `ac_voltage` (32200). uint16, scale 0.1 V. |
+| 37005 | Integer SoC without scale. Inferior to `battery_soc` (32104). |
+
+### Per-pack scalars (verified, deliberately not integrated)
+
+Pattern: each pack is offset by +0x100 (pack 1 = 340xx, pack 2 = 341xx, …). Values below confirmed
+across packs 1–5 (pack 6 follows the same pattern; populated only when a 6th pack is present).
+
+| Register (pack 1 / +0x100 per pack) | Key | Notes |
+|----------|-----|-------|
+| 34000 | pack battery voltage | uint16, scale 0.01 V. |
+| 34001 | pack battery current | int16, scale 0.1 A. Negative = discharge. Reads the active pack's current. |
+| 34003 | pack cycle count | uint16. Pack 1's value (34003) is already integrated as `battery_cycle_count`. |
+| 34004 | pack charge status | uint16. 3 = actively charging, 0 = idle. |
+| 34005 | pack max cell voltage | uint16, scale 0.001 V. |
+| 34006 | pack min cell voltage | uint16, scale 0.001 V. |
+| 34007 | pack max NTC temperature | uint16, scale 0.1 °C. |
+| 34008 | pack protection bitmask 1 | uint16 bitmask. Individual bits not fully decoded. |
+| 34009 | pack protection bitmask 2 | uint16 bitmask. Bit 1 (0x0002) = low-SoC/undervoltage (confirmed in discharge test, triggers below ~10.7%). |
+| 34010 | pack BMS version | uint16. 116 → 1177 (v117.7) after BMS firmware update. |
+| 34011 | pack cell NTC 0 | uint16, scale 0.1 °C. |
+| 34012 | pack cell NTC 1 | uint16, scale 0.1 °C. |
+| 34013 | pack cell NTC 2 | uint16, scale 0.1 °C. |
+| 34014 | pack cell NTC 3 | uint16, scale 0.1 °C. |
+| 34015 | pack MOS NTC | uint16, scale 0.1 °C. |
+| 34016 | pack environment NTC | uint16, scale 0.1 °C. |
+| 34017 | pack average NTC | uint16, scale 0.1 °C. |
+
+### Backup / UPS output (verified — candidates for integration)
+
+Distinct from the grid/inverter registers; measured on the backup (off-grid) output. Would need
+new translation keys, hence documented here rather than added blindly.
+
+| Register | Notes |
+|----------|-------|
+| 30005 | Backup/UPS output voltage. uint16, scale 0.1 V. ~1 V when backup inactive; 236–242 V under load (242 V @100 W → 237 V @3 kW). |
+| 30007 | Backup/UPS output power. uint16, scale 1 W. 0 when no backup load; 0–3271 W depending on load on the backup output. |
+
+### Version / misc
+
+| Register | Notes |
+|----------|-------|
+| 30205 | MPPT firmware version. uint16 (observed 104). |

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -8,14 +8,6 @@ MISSING:
     sensor:
         - sn_code
         - software_version
-        - fault_status
-        - alarm_status
-        - battery_soc_unit_1
-        - battery_soc_unit_2
-        - battery_soc_unit_3
-        - battery_soc_unit_4
-        - battery_soc_unit_5
-        - battery_soc_unit_6
     binary:
         - discharge_limit_mode
     select:
@@ -77,6 +69,60 @@ SENSOR_DEFINITIONS:
         device_class: battery
         state_class: measurement
         enabled_by_default: true
+        data_type: uint16
+        precision: 1
+        scan_interval: high
+    battery_soc_1:
+        register: 34002
+        scale: 0.1
+        unit: "%"
+        state_class: measurement
+        enabled_by_default: false
+        data_type: uint16
+        precision: 1
+        scan_interval: high
+    battery_soc_2:
+        register: 34102
+        scale: 0.1
+        unit: "%"
+        state_class: measurement
+        enabled_by_default: false
+        data_type: uint16
+        precision: 1
+        scan_interval: high
+    battery_soc_3:
+        register: 34202
+        scale: 0.1
+        unit: "%"
+        state_class: measurement
+        enabled_by_default: false
+        data_type: uint16
+        precision: 1
+        scan_interval: high
+    battery_soc_4:
+        register: 34302
+        scale: 0.1
+        unit: "%"
+        state_class: measurement
+        enabled_by_default: false
+        data_type: uint16
+        precision: 1
+        scan_interval: high
+    battery_soc_5:
+        register: 34402
+        scale: 0.1
+        unit: "%"
+        state_class: measurement
+        enabled_by_default: false
+        data_type: uint16
+        precision: 1
+        scan_interval: high
+    battery_soc_6:
+        register: 34502
+        scale: 0.1
+        unit: "%"
+        state_class: measurement
+        enabled_by_default: false
         data_type: uint16
         precision: 1
         scan_interval: high
@@ -468,6 +514,508 @@ SENSOR_DEFINITIONS:
         data_type: int16
         precision: 3
         scan_interval: high
+    battery_2_cell_1_voltage:
+        register: 34118
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_2_voltage:
+        register: 34119
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_3_voltage:
+        register: 34120
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_4_voltage:
+        register: 34121
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_5_voltage:
+        register: 34122
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_6_voltage:
+        register: 34123
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_7_voltage:
+        register: 34124
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_8_voltage:
+        register: 34125
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_9_voltage:
+        register: 34126
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_10_voltage:
+        register: 34127
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_11_voltage:
+        register: 34128
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_12_voltage:
+        register: 34129
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_13_voltage:
+        register: 34130
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_14_voltage:
+        register: 34131
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_15_voltage:
+        register: 34132
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_2_cell_16_voltage:
+        register: 34133
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_1_voltage:
+        register: 34218
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_2_voltage:
+        register: 34219
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_3_voltage:
+        register: 34220
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_4_voltage:
+        register: 34221
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_5_voltage:
+        register: 34222
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_6_voltage:
+        register: 34223
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_7_voltage:
+        register: 34224
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_8_voltage:
+        register: 34225
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_9_voltage:
+        register: 34226
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_10_voltage:
+        register: 34227
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_11_voltage:
+        register: 34228
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_12_voltage:
+        register: 34229
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_13_voltage:
+        register: 34230
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_14_voltage:
+        register: 34231
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_15_voltage:
+        register: 34232
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_3_cell_16_voltage:
+        register: 34233
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_1_voltage:
+        register: 34318
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_2_voltage:
+        register: 34319
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_3_voltage:
+        register: 34320
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_4_voltage:
+        register: 34321
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_5_voltage:
+        register: 34322
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_6_voltage:
+        register: 34323
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_7_voltage:
+        register: 34324
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_8_voltage:
+        register: 34325
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_9_voltage:
+        register: 34326
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_10_voltage:
+        register: 34327
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_11_voltage:
+        register: 34328
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_12_voltage:
+        register: 34329
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_13_voltage:
+        register: 34330
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_14_voltage:
+        register: 34331
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_15_voltage:
+        register: 34332
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_4_cell_16_voltage:
+        register: 34333
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    alarm_status:
+        register: 36000
+        count: 2
+        data_type: uint16
+        device_class: problem
+        icon: "mdi:alert"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+        # Venus D: 36000-36001 (uint32). Bit semantics not yet decoded on Venus D (read 0 in all test scans).
+    fault_status:
+        register: 36100
+        count: 4
+        data_type: uint16
+        device_class: problem
+        icon: "mdi:alert"
+        category: diagnostic
+        enabled_by_default: true
+        scan_interval: high
+        # Venus D: 36100-36103 (uint64). Only bit 4 verified (battery-disconnect test); other bits not decoded on Venus D.
+        bit_descriptions:
+            4: BMS offline / Battery disconnected
     inverter_state:
         register: 35100
         scale: 1

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -264,6 +264,15 @@
       "battery_2_cell_13_voltage": {
         "name": "Batteriepack 2 Zelle 13 Spannung"
       },
+      "battery_2_cell_14_voltage": {
+        "name": "Batteriepack 2 Zelle 14 Spannung"
+      },
+      "battery_2_cell_15_voltage": {
+        "name": "Batteriepack 2 Zelle 15 Spannung"
+      },
+      "battery_2_cell_16_voltage": {
+        "name": "Batteriepack 2 Zelle 16 Spannung"
+      },
       "battery_3_cell_1_voltage": {
         "name": "Batteriepack 3 Zelle 1 Spannung"
       },
@@ -303,6 +312,15 @@
       "battery_3_cell_13_voltage": {
         "name": "Batteriepack 3 Zelle 13 Spannung"
       },
+      "battery_3_cell_14_voltage": {
+        "name": "Batteriepack 3 Zelle 14 Spannung"
+      },
+      "battery_3_cell_15_voltage": {
+        "name": "Batteriepack 3 Zelle 15 Spannung"
+      },
+      "battery_3_cell_16_voltage": {
+        "name": "Batteriepack 3 Zelle 16 Spannung"
+      },
       "battery_4_cell_1_voltage": {
         "name": "Batteriepack 4 Zelle 1 Spannung"
       },
@@ -341,6 +359,15 @@
       },
       "battery_4_cell_13_voltage": {
         "name": "Batteriepack 4 Zelle 13 Spannung"
+      },
+      "battery_4_cell_14_voltage": {
+        "name": "Batteriepack 4 Zelle 14 Spannung"
+      },
+      "battery_4_cell_15_voltage": {
+        "name": "Batteriepack 4 Zelle 15 Spannung"
+      },
+      "battery_4_cell_16_voltage": {
+        "name": "Batteriepack 4 Zelle 16 Spannung"
       },
       "battery_5_cell_1_voltage": {
         "name": "Batteriepack 5 Zelle 1 Spannung"

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -267,6 +267,15 @@
       "battery_2_cell_13_voltage": {
         "name": "Battery Pack 2 Cell 13 Voltage"
       },
+      "battery_2_cell_14_voltage": {
+        "name": "Battery Pack 2 Cell 14 Voltage"
+      },
+      "battery_2_cell_15_voltage": {
+        "name": "Battery Pack 2 Cell 15 Voltage"
+      },
+      "battery_2_cell_16_voltage": {
+        "name": "Battery Pack 2 Cell 16 Voltage"
+      },
       "battery_3_cell_1_voltage": {
         "name": "Battery Pack 3 Cell 1 Voltage"
       },
@@ -306,6 +315,15 @@
       "battery_3_cell_13_voltage": {
         "name": "Battery Pack 3 Cell 13 Voltage"
       },
+      "battery_3_cell_14_voltage": {
+        "name": "Battery Pack 3 Cell 14 Voltage"
+      },
+      "battery_3_cell_15_voltage": {
+        "name": "Battery Pack 3 Cell 15 Voltage"
+      },
+      "battery_3_cell_16_voltage": {
+        "name": "Battery Pack 3 Cell 16 Voltage"
+      },
       "battery_4_cell_1_voltage": {
         "name": "Battery Pack 4 Cell 1 Voltage"
       },
@@ -344,6 +362,15 @@
       },
       "battery_4_cell_13_voltage": {
         "name": "Battery Pack 4 Cell 13 Voltage"
+      },
+      "battery_4_cell_14_voltage": {
+        "name": "Battery Pack 4 Cell 14 Voltage"
+      },
+      "battery_4_cell_15_voltage": {
+        "name": "Battery Pack 4 Cell 15 Voltage"
+      },
+      "battery_4_cell_16_voltage": {
+        "name": "Battery Pack 4 Cell 16 Voltage"
       },
       "battery_5_cell_1_voltage": {
         "name": "Battery Pack 5 Cell 1 Voltage"

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -271,6 +271,15 @@
       "battery_2_cell_13_voltage": {
         "name": "Batterij pack 2 Cel 13 Spanning"
       },
+      "battery_2_cell_14_voltage": {
+        "name": "Batterij pack 2 Cel 14 Spanning"
+      },
+      "battery_2_cell_15_voltage": {
+        "name": "Batterij pack 2 Cel 15 Spanning"
+      },
+      "battery_2_cell_16_voltage": {
+        "name": "Batterij pack 2 Cel 16 Spanning"
+      },
       "battery_3_cell_1_voltage": {
         "name": "Batterij pack 3 Cel 1 Spanning"
       },
@@ -310,6 +319,15 @@
       "battery_3_cell_13_voltage": {
         "name": "Batterij pack 3 Cel 13 Spanning"
       },
+      "battery_3_cell_14_voltage": {
+        "name": "Batterij pack 3 Cel 14 Spanning"
+      },
+      "battery_3_cell_15_voltage": {
+        "name": "Batterij pack 3 Cel 15 Spanning"
+      },
+      "battery_3_cell_16_voltage": {
+        "name": "Batterij pack 3 Cel 16 Spanning"
+      },
       "battery_4_cell_1_voltage": {
         "name": "Batterij pack 4 Cel 1 Spanning"
       },
@@ -348,6 +366,15 @@
       },
       "battery_4_cell_13_voltage": {
         "name": "Batterij pack 4 Cel 13 Spanning"
+      },
+      "battery_4_cell_14_voltage": {
+        "name": "Batterij pack 4 Cel 14 Spanning"
+      },
+      "battery_4_cell_15_voltage": {
+        "name": "Batterij pack 4 Cel 15 Spanning"
+      },
+      "battery_4_cell_16_voltage": {
+        "name": "Batterij pack 4 Cel 16 Spanning"
       },
       "battery_5_cell_1_voltage": {
         "name": "Batterij pack 5 Cel 1 Spanning"


### PR DESCRIPTION
Fill in registers previously flagged as MISSING/untested in d.yaml, using read-back values cross-checked on real Venus D hardware:

- battery_soc_1..6 (34002/34102/34202/34302/34402/34502)
- battery_2/3/4_cell_1..16_voltage (34118-34133 / 34218-34233 / 34318-34333; Venus D packs carry 16 cells vs. 13 on Venus A) incl. en/de/nl translations for cells 14-16
- alarm_status (36000) and fault_status (36100); only the Venus-D-verified fault bit (4 = BMS offline / battery disconnected) is decoded, other bits left undecoded rather than inherited from Venus E

Additional verified-but-not-integrated registers (mirrors, per-pack scalars, backup/UPS output, MPPT version) documented in registers/README.md, following the existing Venus A/E policy of integrating only per-pack SoC and cell voltages.