### PR TITLE
Venus D: add pack 5 and 6 cell voltages

### DIFF
--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -65,9 +65,12 @@ All registers below were read back and cross-checked on real hardware, but are *
 integration — following the same policy applied to Venus A/E, which integrates only per-pack SoC and
 per-pack cell voltages, not the remaining per-pack scalars.
 
-Integrated in this PR (for reference): `battery_soc_1..6` (34002/34102/34202/34302/34402/34502),
-`battery_2/3/4_cell_1..16_voltage` (34118–34133 / 34218–34233 / 34318–34333, 16 cells per pack —
-Venus D packs carry 16 cells vs. 13 on Venus A), `alarm_status` (36000), `fault_status` (36100).
+Integrated (for reference): `battery_soc_1..6` (34002/34102/34202/34302/34402/34502),
+`battery_2..6_cell_1..16_voltage` (34118–34133 / 34218–34233 / 34318–34333 / 34418–34433 / 34518–34533,
+16 cells per pack — Venus D packs carry 16 cells vs. 13 on Venus A), `alarm_status` (36000),
+`fault_status` (36100). Pack 1 cell voltages (34018–34033) were already present.
+Packs 2–4 cell voltages are FW-confirmed; packs 5–6 follow the identical +0x100 register pattern
+(pattern-derived, same treatment as Venus A `a.yaml`).
 
 ### Mirrors / inferior duplicates of already-integrated sensors
 

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -994,6 +994,326 @@ SENSOR_DEFINITIONS:
         data_type: int16
         precision: 3
         scan_interval: high
+    battery_5_cell_1_voltage:
+        register: 34418
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_2_voltage:
+        register: 34419
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_3_voltage:
+        register: 34420
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_4_voltage:
+        register: 34421
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_5_voltage:
+        register: 34422
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_6_voltage:
+        register: 34423
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_7_voltage:
+        register: 34424
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_8_voltage:
+        register: 34425
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_9_voltage:
+        register: 34426
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_10_voltage:
+        register: 34427
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_11_voltage:
+        register: 34428
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_12_voltage:
+        register: 34429
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_13_voltage:
+        register: 34430
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_14_voltage:
+        register: 34431
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_15_voltage:
+        register: 34432
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_5_cell_16_voltage:
+        register: 34433
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_1_voltage:
+        register: 34518
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_2_voltage:
+        register: 34519
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_3_voltage:
+        register: 34520
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_4_voltage:
+        register: 34521
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_5_voltage:
+        register: 34522
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_6_voltage:
+        register: 34523
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_7_voltage:
+        register: 34524
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_8_voltage:
+        register: 34525
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_9_voltage:
+        register: 34526
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_10_voltage:
+        register: 34527
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_11_voltage:
+        register: 34528
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_12_voltage:
+        register: 34529
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_13_voltage:
+        register: 34530
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_14_voltage:
+        register: 34531
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_15_voltage:
+        register: 34532
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
+    battery_6_cell_16_voltage:
+        register: 34533
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        enabled_by_default: false
+        data_type: int16
+        precision: 3
+        scan_interval: high
     alarm_status:
         register: 36000
         count: 2

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -408,6 +408,15 @@
       "battery_5_cell_13_voltage": {
         "name": "Batteriepack 5 Zelle 13 Spannung"
       },
+      "battery_5_cell_14_voltage": {
+        "name": "Batteriepack 5 Zelle 14 Spannung"
+      },
+      "battery_5_cell_15_voltage": {
+        "name": "Batteriepack 5 Zelle 15 Spannung"
+      },
+      "battery_5_cell_16_voltage": {
+        "name": "Batteriepack 5 Zelle 16 Spannung"
+      },
       "battery_6_cell_1_voltage": {
         "name": "Batteriepack 6 Zelle 1 Spannung"
       },
@@ -446,6 +455,15 @@
       },
       "battery_6_cell_13_voltage": {
         "name": "Batteriepack 6 Zelle 13 Spannung"
+      },
+      "battery_6_cell_14_voltage": {
+        "name": "Batteriepack 6 Zelle 14 Spannung"
+      },
+      "battery_6_cell_15_voltage": {
+        "name": "Batteriepack 6 Zelle 15 Spannung"
+      },
+      "battery_6_cell_16_voltage": {
+        "name": "Batteriepack 6 Zelle 16 Spannung"
       },
       "inverter_state": {
         "name": "Wechselrichter-Status",

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -411,6 +411,15 @@
       "battery_5_cell_13_voltage": {
         "name": "Battery Pack 5 Cell 13 Voltage"
       },
+      "battery_5_cell_14_voltage": {
+        "name": "Battery Pack 5 Cell 14 Voltage"
+      },
+      "battery_5_cell_15_voltage": {
+        "name": "Battery Pack 5 Cell 15 Voltage"
+      },
+      "battery_5_cell_16_voltage": {
+        "name": "Battery Pack 5 Cell 16 Voltage"
+      },
       "battery_6_cell_1_voltage": {
         "name": "Battery Pack 6 Cell 1 Voltage"
       },
@@ -449,6 +458,15 @@
       },
       "battery_6_cell_13_voltage": {
         "name": "Battery Pack 6 Cell 13 Voltage"
+      },
+      "battery_6_cell_14_voltage": {
+        "name": "Battery Pack 6 Cell 14 Voltage"
+      },
+      "battery_6_cell_15_voltage": {
+        "name": "Battery Pack 6 Cell 15 Voltage"
+      },
+      "battery_6_cell_16_voltage": {
+        "name": "Battery Pack 6 Cell 16 Voltage"
       },
       "inverter_state": {
         "name": "Inverter State",

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -415,6 +415,15 @@
       "battery_5_cell_13_voltage": {
         "name": "Batterij pack 5 Cel 13 Spanning"
       },
+      "battery_5_cell_14_voltage": {
+        "name": "Batterij pack 5 Cel 14 Spanning"
+      },
+      "battery_5_cell_15_voltage": {
+        "name": "Batterij pack 5 Cel 15 Spanning"
+      },
+      "battery_5_cell_16_voltage": {
+        "name": "Batterij pack 5 Cel 16 Spanning"
+      },
       "battery_6_cell_1_voltage": {
         "name": "Batterij pack 6 Cel 1 Spanning"
       },
@@ -453,6 +462,15 @@
       },
       "battery_6_cell_13_voltage": {
         "name": "Batterij pack 6 Cel 13 Spanning"
+      },
+      "battery_6_cell_14_voltage": {
+        "name": "Batterij pack 6 Cel 14 Spanning"
+      },
+      "battery_6_cell_15_voltage": {
+        "name": "Batterij pack 6 Cel 15 Spanning"
+      },
+      "battery_6_cell_16_voltage": {
+        "name": "Batterij pack 6 Cel 16 Spanning"
       },
       "inverter_state": {
         "name": "Omvormer Status",


### PR DESCRIPTION
# Venus D: add pack 5 and 6 cell voltages

Follow-up to #279. That PR added per-pack cell voltages for packs 2–4 (pack 1 was already
present). This completes the set so all six packs are symmetric — 16 cells each.

## Added to `d.yaml`

| Sensors | Registers |
|---|---|
| `battery_5_cell_1..16_voltage` | 34418–34433 |
| `battery_6_cell_1..16_voltage` | 34518–34533 |

Plus en/de/nl translations for cells 14–16 of packs 5 and 6 (cells 1–13 already existed).
All sensors are disabled by default, matching the other per-pack cell voltages.

## Note on confidence

Packs 2–4 cell voltages are FW-confirmed on real hardware. Packs 5–6 follow the identical
`+0x100` per-pack register pattern and are **pattern-derived** rather than individually verified —
the same treatment Venus A (`a.yaml`) already gives packs 5–6. `registers/README.md` is updated
to state this explicitly.

No logic changes; no duplicate register addresses introduced.
