### PR TITLE
Venus D: add firmware-decoded diagnostic sensors + document register map

### DIFF
--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -113,8 +113,39 @@ new translation keys, hence documented here rather than added blindly.
 | 30005 | Backup/UPS output voltage. uint16, scale 0.1 V. ~1 V when backup inactive; 236–242 V under load (242 V @100 W → 237 V @3 kW). |
 | 30007 | Backup/UPS output power. uint16, scale 1 W. 0 when no backup load; 0–3271 W depending on load on the backup output. |
 
-### Version / misc
+### Firmware descriptor-table analysis (v150)
 
-| Register | Notes |
-|----------|-------|
-| 30205 | MPPT firmware version. uint16 (observed 104). |
+A later pass decoded the device's on-firmware descriptor tables (FC03 read descriptors, plus the
+FC06/FC10 write-handler table with their SRAM targets). This is authoritative for register names,
+types and layout. Findings folded into the integration and this document:
+
+**Newly integrated diagnostic sensors** (all `category: diagnostic`, disabled by default):
+
+| Register | Sensor | Notes |
+|----------|--------|-------|
+| 30205 | `mppt_version` | MPPT firmware version (u16, observed 104). |
+| 32109 | `bms_pack_count` | Number of packs the BMS reports present (CAN `bat_total_nb`). |
+| 32110 | `bms_online_mask` | u16 bitmask: which packs are online (`bat_online_mask`). |
+| 32111 | `bms_active_pack_index` | Index of the currently active pack (`work_bat_idx`). |
+| 35110 | `bms_charge_voltage_limit` | BMS charge voltage limit, 0.1 V (CAN `chrg_volt`, observed 57.6 V). |
+| 37023 | `mppt_error` | MPPT error word (Inverter struct +0x02). |
+| 37024 | `mppt_warning` | MPPT warning word (Inverter struct +0x06). |
+
+**Write/control registers — confirmed already integrated.** The firmware write-handler table matches
+the existing `number`/`select`/`switch`/`button` definitions (e.g. 42020/42021 charge/discharge power,
+44002/44003 max power, 42011 target SoC, 42010 force mode, 43000 work mode, 41200 backup, schedules).
+No change needed — the decode simply validates them.
+
+**Write registers intentionally NOT integrated** (decoded from firmware but never write-tested;
+some are hazardous to expose as live entities):
+
+| Register | Firmware name | Why excluded |
+|----------|---------------|--------------|
+| 40000 | `rs485_unlock` | Enables RS485 control; unclear side effects, no display scale. |
+| 41100 | `modbus_slave_address` | Changing it silently breaks Modbus communication. |
+| 41500–41631 | `schedule_time_XX` / `schedule_power_XX` | Raw schedule arrays; integration already models schedules via 43100+. |
+
+**Note on the earlier `MISSING:` config registers.** The Venus-E-derived addresses (`software_version`
+31100, `sn_code` 31200, cutoff 44000/44001, `grid_standard` 44100, `discharge_limit_mode` 41010) do
+**not** appear in the Venus D firmware descriptor tables — they likely do not exist on Venus D, or live
+at different addresses. They should not be copied over from other models without hardware confirmation.

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1206,6 +1206,60 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: high
+    # --- Firmware-decoded diagnostic sensors (Venus D, from descriptor-table analysis) ---
+    bms_pack_count:
+        register: 32109
+        data_type: uint16
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    bms_online_mask:
+        register: 32110
+        data_type: uint16
+        icon: "mdi:format-list-checks"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    bms_active_pack_index:
+        register: 32111
+        data_type: uint16
+        icon: "mdi:battery-sync"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    bms_charge_voltage_limit:
+        register: 35110
+        scale: 0.1
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    mppt_error:
+        register: 37023
+        data_type: uint16
+        icon: "mdi:alert"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    mppt_warning:
+        register: 37024
+        data_type: uint16
+        icon: "mdi:alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    mppt_version:
+        register: 30205
+        data_type: uint16
+        icon: "mdi:ticket-confirmation-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -63,6 +63,27 @@
   },
   "entity": {
     "sensor": {
+      "bms_pack_count": {
+        "name": "BMS Pack-Anzahl"
+      },
+      "bms_online_mask": {
+        "name": "BMS Online-Maske"
+      },
+      "bms_active_pack_index": {
+        "name": "BMS Aktiver Pack-Index"
+      },
+      "bms_charge_voltage_limit": {
+        "name": "BMS Ladespannungs-Limit"
+      },
+      "mppt_error": {
+        "name": "MPPT-Fehler"
+      },
+      "mppt_warning": {
+        "name": "MPPT-Warnung"
+      },
+      "mppt_version": {
+        "name": "MPPT-Version"
+      },
       "device_name": {
         "name": "Gerätename"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -63,6 +63,27 @@
   },
   "entity": {
     "sensor": {
+      "bms_pack_count": {
+        "name": "BMS Pack Count"
+      },
+      "bms_online_mask": {
+        "name": "BMS Online Mask"
+      },
+      "bms_active_pack_index": {
+        "name": "BMS Active Pack Index"
+      },
+      "bms_charge_voltage_limit": {
+        "name": "BMS Charge Voltage Limit"
+      },
+      "mppt_error": {
+        "name": "MPPT Error"
+      },
+      "mppt_warning": {
+        "name": "MPPT Warning"
+      },
+      "mppt_version": {
+        "name": "MPPT Version"
+      },
       "device_name": {
         "name": "Device Name"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -67,6 +67,27 @@
   },
   "entity": {
     "sensor": {
+      "bms_pack_count": {
+        "name": "BMS Pack aantal"
+      },
+      "bms_online_mask": {
+        "name": "BMS Online masker"
+      },
+      "bms_active_pack_index": {
+        "name": "BMS Actieve pack-index"
+      },
+      "bms_charge_voltage_limit": {
+        "name": "BMS Laadspanningslimiet"
+      },
+      "mppt_error": {
+        "name": "MPPT-fout"
+      },
+      "mppt_warning": {
+        "name": "MPPT-waarschuwing"
+      },
+      "mppt_version": {
+        "name": "MPPT-versie"
+      },
       "device_name": {
         "name": "Apparaatnaam"
       },


### PR DESCRIPTION
# Venus D: firmware-decoded diagnostic sensors + register-map documentation

Source: decoded the device's on-firmware descriptor tables — the FC03 read descriptors and the
FC06/FC10 write-handler table (with SRAM targets). That's authoritative for register names, types
and layout, so it both adds a few genuinely new sensors and validates what's already integrated.

## Added to `d.yaml` (all `category: diagnostic`, disabled by default)

| Register | Sensor | Notes |
|---|---|---|
| 30205 | `mppt_version` | MPPT firmware version. |
| 32109 | `bms_pack_count` | Number of packs the BMS reports present. |
| 32110 | `bms_online_mask` | u16 bitmask of online packs. |
| 32111 | `bms_active_pack_index` | Currently active pack index. |
| 35110 | `bms_charge_voltage_limit` | BMS charge-voltage limit (0.1 V, observed 57.6 V). |
| 37023 | `mppt_error` | MPPT error word. |
| 37024 | `mppt_warning` | MPPT warning word. |

Plus en/de/nl translations for all seven.

## `registers/README.md` (Venus D section)

Extended with a "Firmware descriptor-table analysis" subsection:

- The newly integrated sensors above.
- Confirmation that the existing `number`/`select`/`switch`/`button` write registers
  (42020/42021, 44002/44003, 42011, 42010, 43000, 41200, schedules, …) match the firmware
  write-handler table — no change needed, just validated.
- An explicit list of write registers **left out on purpose** because they are untested and/or
  hazardous to expose as live entities: `rs485_unlock` (40000), `modbus_slave_address` (41100),
  and the raw `schedule_time/power` arrays (41500–41631).
- A note that the Venus-E-derived `MISSING:` config registers (`software_version` 31100,
  `sn_code` 31200, cutoffs 44000/44001, `grid_standard` 44100, `discharge_limit_mode` 41010)
  do **not** appear in the Venus D firmware, so they shouldn't be copied from other models.

## Deliberately no write entities

The useful/safe control registers are already in the integration. The remaining firmware write
registers are either redundant or unsafe to expose untested, so they are documented, not added.

No duplicate register addresses; YAML/JSON validated.
