### PR TITLE
VNSD firmware version format

### DIFF
--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -113,8 +113,39 @@ new translation keys, hence documented here rather than added blindly.
 | 30005 | Backup/UPS output voltage. uint16, scale 0.1 V. ~1 V when backup inactive; 236–242 V under load (242 V @100 W → 237 V @3 kW). |
 | 30007 | Backup/UPS output power. uint16, scale 1 W. 0 when no backup load; 0–3271 W depending on load on the backup output. |
 
-### Version / misc
+### Firmware descriptor-table analysis (v150)
 
-| Register | Notes |
-|----------|-------|
-| 30205 | MPPT firmware version. uint16 (observed 104). |
+A later pass decoded the device's on-firmware descriptor tables (FC03 read descriptors, plus the
+FC06/FC10 write-handler table with their SRAM targets). This is authoritative for register names,
+types and layout. Findings folded into the integration and this document:
+
+**Newly integrated diagnostic sensors** (all `category: diagnostic`, disabled by default):
+
+| Register | Sensor | Notes |
+|----------|--------|-------|
+| 30205 | `mppt_version` | MPPT firmware version (u16, observed 104). |
+| 32109 | `bms_pack_count` | Number of packs the BMS reports present (CAN `bat_total_nb`). |
+| 32110 | `bms_online_mask` | u16 bitmask: which packs are online (`bat_online_mask`). |
+| 32111 | `bms_active_pack_index` | Index of the currently active pack (`work_bat_idx`). |
+| 35110 | `bms_charge_voltage_limit` | BMS charge voltage limit, 0.1 V (CAN `chrg_volt`, observed 57.6 V). |
+| 37023 | `mppt_error` | MPPT error word (Inverter struct +0x02). |
+| 37024 | `mppt_warning` | MPPT warning word (Inverter struct +0x06). |
+
+**Write/control registers — confirmed already integrated.** The firmware write-handler table matches
+the existing `number`/`select`/`switch`/`button` definitions (e.g. 42020/42021 charge/discharge power,
+44002/44003 max power, 42011 target SoC, 42010 force mode, 43000 work mode, 41200 backup, schedules).
+No change needed — the decode simply validates them.
+
+**Write registers intentionally NOT integrated** (decoded from firmware but never write-tested;
+some are hazardous to expose as live entities):
+
+| Register | Firmware name | Why excluded |
+|----------|---------------|--------------|
+| 40000 | `rs485_unlock` | Enables RS485 control; unclear side effects, no display scale. |
+| 41100 | `modbus_slave_address` | Changing it silently breaks Modbus communication. |
+| 41500–41631 | `schedule_time_XX` / `schedule_power_XX` | Raw schedule arrays; integration already models schedules via 43100+. |
+
+**Note on the earlier `MISSING:` config registers.** The Venus-E-derived addresses (`software_version`
+31100, `sn_code` 31200, cutoff 44000/44001, `grid_standard` 44100, `discharge_limit_mode` 41010) do
+**not** appear in the Venus D firmware descriptor tables — they likely do not exist on Venus D, or live
+at different addresses. They should not be copied over from other models without hardware confirmation.

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1732,10 +1732,11 @@ VERSION_SENSOR_DEFINITIONS:
         icon: "mdi:chip"
         category: diagnostic
         enabled_by_default: true
-        mode: ems_vms_bms
+        mode: ems_vms_mppt_bms
         dependency_keys:
             ems: ems_version
             vms: vms_version
+            mppt: mppt_version
             bms: bms_version
 
 EFFICIENCY_SENSOR_DEFINITIONS:

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1206,6 +1206,60 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: high
+    # --- Firmware-decoded diagnostic sensors (Venus D, from descriptor-table analysis) ---
+    bms_pack_count:
+        register: 32109
+        data_type: uint16
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    bms_online_mask:
+        register: 32110
+        data_type: uint16
+        icon: "mdi:format-list-checks"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    bms_active_pack_index:
+        register: 32111
+        data_type: uint16
+        icon: "mdi:battery-sync"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    bms_charge_voltage_limit:
+        register: 35110
+        scale: 0.1
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    mppt_error:
+        register: 37023
+        data_type: uint16
+        icon: "mdi:alert"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    mppt_warning:
+        register: 37024
+        data_type: uint16
+        icon: "mdi:alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    mppt_version:
+        register: 30205
+        data_type: uint16
+        icon: "mdi:ticket-confirmation-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/sensor.py
+++ b/custom_components/marstek_modbus/sensor.py
@@ -539,6 +539,9 @@ class MarstekVersionSensor(MarstekCalculatedSensor):
                     into a string like "V147.6.112"
                 - "ems_vms_bms": combines ems_version + vms_version + bms_version
                     into a string like "V147.6.117.112"
+                - "ems_vms_mppt_bms": combines ems_version + vms_version + mppt_version
+                    + bms_version into a string like "V149.2.115.104.118" (for models
+                    with an MPPT stage, e.g. Venus D)
     """
 
     def _calculate(self, data: dict) -> None:
@@ -559,7 +562,7 @@ class MarstekVersionSensor(MarstekCalculatedSensor):
 
     def calculate_value(self, raw_values: dict):
         mode = self.definition.get("mode")
-        if mode in ("ems_bms", "ems_vms_bms"):
+        if mode in ("ems_bms", "ems_vms_bms", "ems_vms_mppt_bms"):
             ems_raw = int(raw_values["ems"])
             bms = int(raw_values["bms"])
             vms_raw = raw_values.get("vms")
@@ -572,12 +575,21 @@ class MarstekVersionSensor(MarstekCalculatedSensor):
             if mode == "ems_bms":
                 return f"V{ems_str}.{bms}"
 
-            # ems_vms_bms expects the third version part.
+            # ems_vms_bms / ems_vms_mppt_bms expect a vms part.
             if vms_raw is None:
                 _LOGGER.warning("%s missing vms for mode '%s'", self._key, mode)
                 return None
-
             vms = int(vms_raw)
-            return f"V{ems_str}.{vms}.{bms}"
+
+            if mode == "ems_vms_bms":
+                return f"V{ems_str}.{vms}.{bms}"
+
+            # ems_vms_mppt_bms adds the MPPT firmware version (Venus D/A).
+            mppt_raw = raw_values.get("mppt")
+            if mppt_raw is None:
+                _LOGGER.warning("%s missing mppt for mode '%s'", self._key, mode)
+                return None
+            mppt = int(mppt_raw)
+            return f"V{ems_str}.{vms}.{mppt}.{bms}"
         _LOGGER.warning("%s unknown version mode '%s'", self._key, mode)
         return None

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -63,6 +63,27 @@
   },
   "entity": {
     "sensor": {
+      "bms_pack_count": {
+        "name": "BMS Pack-Anzahl"
+      },
+      "bms_online_mask": {
+        "name": "BMS Online-Maske"
+      },
+      "bms_active_pack_index": {
+        "name": "BMS Aktiver Pack-Index"
+      },
+      "bms_charge_voltage_limit": {
+        "name": "BMS Ladespannungs-Limit"
+      },
+      "mppt_error": {
+        "name": "MPPT-Fehler"
+      },
+      "mppt_warning": {
+        "name": "MPPT-Warnung"
+      },
+      "mppt_version": {
+        "name": "MPPT-Version"
+      },
       "device_name": {
         "name": "Gerätename"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -63,6 +63,27 @@
   },
   "entity": {
     "sensor": {
+      "bms_pack_count": {
+        "name": "BMS Pack Count"
+      },
+      "bms_online_mask": {
+        "name": "BMS Online Mask"
+      },
+      "bms_active_pack_index": {
+        "name": "BMS Active Pack Index"
+      },
+      "bms_charge_voltage_limit": {
+        "name": "BMS Charge Voltage Limit"
+      },
+      "mppt_error": {
+        "name": "MPPT Error"
+      },
+      "mppt_warning": {
+        "name": "MPPT Warning"
+      },
+      "mppt_version": {
+        "name": "MPPT Version"
+      },
       "device_name": {
         "name": "Device Name"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -67,6 +67,27 @@
   },
   "entity": {
     "sensor": {
+      "bms_pack_count": {
+        "name": "BMS Pack aantal"
+      },
+      "bms_online_mask": {
+        "name": "BMS Online masker"
+      },
+      "bms_active_pack_index": {
+        "name": "BMS Actieve pack-index"
+      },
+      "bms_charge_voltage_limit": {
+        "name": "BMS Laadspanningslimiet"
+      },
+      "mppt_error": {
+        "name": "MPPT-fout"
+      },
+      "mppt_warning": {
+        "name": "MPPT-waarschuwing"
+      },
+      "mppt_version": {
+        "name": "MPPT-versie"
+      },
       "device_name": {
         "name": "Apparaatnaam"
       },


### PR DESCRIPTION
# Venus D: include MPPT firmware version in the composite `firmware_version`

The Venus D `firmware_version` sensor omitted the MPPT stage. It showed e.g.
`V1492.116.118` (EMS.VNS.BMS) instead of the full `V149.2.115.104.118`
(EMS.VNS.MPPT.BMS).

## Change

- New version mode **`ems_vms_mppt_bms`** in `MarstekVersionSensor`: appends the MPPT
  firmware version between VNS and BMS. Existing modes `ems_bms` and `ems_vms_bms` are
  untouched.
- Venus D `firmware_version` switched to the new mode, with `mppt -> mppt_version`
  (register 30205) added to `dependency_keys`.

## Notes

- **No rounding / normalization.** EMS decoding is unchanged: a 4-digit value encodes
  tenths (`1492 -> 149.2`), a 3-digit value is whole (`150`). Different firmware releases
  legitimately report different values (e.g. EMS 149.2 vs 150, VNS 115 vs 116) — the string
  just reflects the exact registers.
- **Model scope:** only Venus D here. Venus E has no MPPT and keeps `ems_bms`. Venus A also
  has an MPPT stage and could use the same mode, but is left out until its `mppt_version`
  register is confirmed on hardware.
- **Depends on `mppt_version` (30205)**, added together with the firmware-decoded diagnostic
  sensors. Merge that change first (or merge them together).

## Verified

`calculate_value` outputs:
- Venus D, 149.2 firmware → `V149.2.115.104.118`
- Venus D, 150 firmware → `V150.116.104.118`
- Venus E (`ems_bms`) → `V147.6.112` (unchanged)
- `ems_vms_bms` → `V147.6.117.112` (unchanged)
