### PR TITLE
Venus D: integrate per-pack health sensors (temperatures, protection, cell extremes)

### DIFF
--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -92,8 +92,8 @@ block (34013–34016 → `battery_N_cell_temperature_1..4`), the cell-voltage ex
 
 | Register (pack 1 / +0x100 per pack) | Key | Notes |
 |----------|-----|-------|
-| 34000 | pack battery voltage | uint16, scale 0.01 V. |
-| 34001 | pack battery current | int16, scale 0.1 A. Negative = discharge. Reads the active pack's current. |
+| 34000 | pack battery voltage | uint16, scale 0.01 V. Pack 1 = `battery_voltage`; packs 2–6 **integrated** as `battery_N_voltage`. |
+| 34001 | pack battery current | int16, scale 0.1 A. Negative = discharge. Pack 1 = `battery_current`; packs 2–6 **integrated** as `battery_N_current`. |
 | 34003 | pack cycle count | int16. Pack 1's value (34003) is `battery_cycle_count`; packs 2–6 **integrated** as `battery_N_cycle_count`. |
 | 34004 | pack MOS status | u8. BMS charge/discharge MOSFET state (Chg/Dsg MOS). **Integrated** as `battery_N_mos_status`. |
 | 34005 | pack max cell voltage | uint16, scale 0.001 V. **Integrated** as `battery_N_max_cell_voltage`. |
@@ -106,6 +106,21 @@ block (34013–34016 → `battery_N_cell_temperature_1..4`), the cell-voltage ex
 | 34012 | pack MOS NTC (MOSFET) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 1". **Integrated** as `battery_N_mos_temperature`. |
 | 34013–34016 | pack cell NTC block | uint16 ×4, scale 0.1 °C (pack struct +0x40). **Integrated** as `battery_N_cell_temperature_1..4`. |
 | 34017 | pack NTC (unused) | uint16, scale 0.1 °C. BMS frame 0x41 bytes 6–7 are not populated. |
+
+### Alternative / redundant sources (firmware-confirmed, intentionally not integrated)
+
+These are valid firmware registers, but each duplicates a value already exposed through a better
+source, so they are documented rather than added as extra entities.
+
+| Register | Firmware name | Why not integrated |
+|----------|---------------|--------------------|
+| 30028 | `inv_bat_voltage` | Inverter-measured battery voltage (0.1 V). Alternative to `battery_voltage` (30100). |
+| 30029 | `inv_bat_current` | Inverter-measured battery current (0.1 A). Alternative to `battery_current` (30101). |
+| 32100 | `bms_battery_voltage` | BMS/CAN aggregate battery voltage (0.01 V). Alternative to `battery_voltage`. |
+| 32101 | `bms_battery_current` | BMS/CAN aggregate battery current (1 A). Coarser alternative to `battery_current`. |
+| 32102 | `bat_sample_power` | Battery power as float32. Alternative to `battery_power` (30001, int16 W). |
+| 37017–37020 | `mppt1..4_power` | Same source as `mppt1..4_power` (30037–30040), which are already integrated. |
+| 37002 / 37003 | `max_charge_power` / `max_discharge_power` | Read-back of the power limits already exposed as the `max_charge_power` / `max_discharge_power` number entities. |
 
 ### Backup / UPS output (verified — candidates for integration)
 

--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -78,11 +78,15 @@ Venus D packs carry 16 cells vs. 13 on Venus A), `alarm_status` (36000), `fault_
 | 30004 | Mirror of `ac_voltage` (32200). uint16, scale 0.1 V. |
 | 37005 | Integer SoC without scale. Inferior to `battery_soc` (32104). |
 
-### Per-pack scalars (verified, deliberately not integrated)
+### Per-pack scalars
 
 Pattern: each pack is offset by +0x100 (pack 1 = 340xx, pack 2 = 341xx, …). Values below confirmed
 across packs 1–5 (pack 6 follows the same pattern; populated only when a 6th pack is present).
 Layout updated per the 2026-08-16 firmware descriptor-table correction (BMS CAN frames 0x23 / 0x41).
+
+The per-pack temperatures (34011/34012) and protection bitmasks (34007/34008) are now integrated for
+packs 1–6 as `battery_N_env_temperature`, `battery_N_mos_temperature`, `battery_N_protection_1` and
+`battery_N_protection_2` (diagnostic, disabled by default). The remaining rows stay reference-only.
 
 | Register (pack 1 / +0x100 per pack) | Key | Notes |
 |----------|-----|-------|
@@ -92,12 +96,12 @@ Layout updated per the 2026-08-16 firmware descriptor-table correction (BMS CAN 
 | 34004 | pack MOS status | u8. BMS charge/discharge MOSFET state (Chg/Dsg MOS). |
 | 34005 | pack max cell voltage | uint16, scale 0.001 V. |
 | 34006 | pack min cell voltage | uint16, scale 0.001 V. |
-| 34007 | pack protection bitmask 1 | int16 bitmask (BMS CAN frame 0x23, protect1). |
-| 34008 | pack protection bitmask 2 | uint16 bitmask (frame 0x23, protect2). A low-SoC/undervoltage bit (0x0002) was observed here during discharge testing (triggers below ~10.7%). |
+| 34007 | pack protection bitmask 1 | int16 bitmask (BMS CAN frame 0x23, protect1). **Integrated** as `battery_N_protection_1`. |
+| 34008 | pack protection bitmask 2 | uint16 bitmask (frame 0x23, protect2). A low-SoC/undervoltage bit (0x0002) was observed here during discharge testing (triggers below ~10.7%). **Integrated** as `battery_N_protection_2`. |
 | 34009 | pack BMS reserved | uint16. BMS-struct field @+0x5a; not named in the firmware debug print. |
 | 34010 | pack BMS version | uint16. 116 → 1177 (v117.7) after BMS firmware update. |
-| 34011 | pack ENV NTC (ambient) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 0". |
-| 34012 | pack MOS NTC (MOSFET) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 1". |
+| 34011 | pack ENV NTC (ambient) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 0". **Integrated** as `battery_N_env_temperature`. |
+| 34012 | pack MOS NTC (MOSFET) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 1". **Integrated** as `battery_N_mos_temperature`. |
 | 34013–34016 | pack cell NTC block | uint16 ×4, scale 0.1 °C (pack struct +0x40). |
 | 34017 | pack NTC (unused) | uint16, scale 0.1 °C. BMS frame 0x41 bytes 6–7 are not populated. |
 

--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -94,14 +94,14 @@ block (34013–34016 → `battery_N_cell_temperature_1..4`), the cell-voltage ex
 |----------|-----|-------|
 | 34000 | pack battery voltage | uint16, scale 0.01 V. |
 | 34001 | pack battery current | int16, scale 0.1 A. Negative = discharge. Reads the active pack's current. |
-| 34003 | pack cycle count | int16. Pack 1's value (34003) is already integrated as `battery_cycle_count`. |
-| 34004 | pack MOS status | u8. BMS charge/discharge MOSFET state (Chg/Dsg MOS). |
+| 34003 | pack cycle count | int16. Pack 1's value (34003) is `battery_cycle_count`; packs 2–6 **integrated** as `battery_N_cycle_count`. |
+| 34004 | pack MOS status | u8. BMS charge/discharge MOSFET state (Chg/Dsg MOS). **Integrated** as `battery_N_mos_status`. |
 | 34005 | pack max cell voltage | uint16, scale 0.001 V. **Integrated** as `battery_N_max_cell_voltage`. |
 | 34006 | pack min cell voltage | uint16, scale 0.001 V. **Integrated** as `battery_N_min_cell_voltage`. |
 | 34007 | pack protection bitmask 1 | int16 bitmask (BMS CAN frame 0x23, protect1). **Integrated** as `battery_N_protection_1`. |
 | 34008 | pack protection bitmask 2 | uint16 bitmask (frame 0x23, protect2). A low-SoC/undervoltage bit (0x0002) was observed here during discharge testing (triggers below ~10.7%). **Integrated** as `battery_N_protection_2`. |
 | 34009 | pack BMS reserved | uint16. BMS-struct field @+0x5a; not named in the firmware debug print. |
-| 34010 | pack BMS version | uint16. 116 → 1177 (v117.7) after BMS firmware update. |
+| 34010 | pack BMS version | uint16. 116 → 1177 (v117.7) after BMS firmware update. **Integrated** as `battery_N_bms_version`. |
 | 34011 | pack ENV NTC (ambient) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 0". **Integrated** as `battery_N_env_temperature`. |
 | 34012 | pack MOS NTC (MOSFET) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 1". **Integrated** as `battery_N_mos_temperature`. |
 | 34013–34016 | pack cell NTC block | uint16 ×4, scale 0.1 °C (pack struct +0x40). **Integrated** as `battery_N_cell_temperature_1..4`. |

--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -84,9 +84,11 @@ Pattern: each pack is offset by +0x100 (pack 1 = 340xx, pack 2 = 341xx, …). Va
 across packs 1–5 (pack 6 follows the same pattern; populated only when a 6th pack is present).
 Layout updated per the 2026-08-16 firmware descriptor-table correction (BMS CAN frames 0x23 / 0x41).
 
-The per-pack temperatures (34011/34012) and protection bitmasks (34007/34008) are now integrated for
-packs 1–6 as `battery_N_env_temperature`, `battery_N_mos_temperature`, `battery_N_protection_1` and
-`battery_N_protection_2` (diagnostic, disabled by default). The remaining rows stay reference-only.
+The per-pack health registers are now integrated for packs 1–6 (all disabled by default):
+temperatures (34011/34012 → `battery_N_env_temperature` / `battery_N_mos_temperature`), the cell-NTC
+block (34013–34016 → `battery_N_cell_temperature_1..4`), the cell-voltage extremes (34005/34006 →
+`battery_N_max_cell_voltage` / `battery_N_min_cell_voltage`), and the protection bitmasks (34007/34008 →
+`battery_N_protection_1` / `battery_N_protection_2`). The remaining rows stay reference-only.
 
 | Register (pack 1 / +0x100 per pack) | Key | Notes |
 |----------|-----|-------|
@@ -94,15 +96,15 @@ packs 1–6 as `battery_N_env_temperature`, `battery_N_mos_temperature`, `batter
 | 34001 | pack battery current | int16, scale 0.1 A. Negative = discharge. Reads the active pack's current. |
 | 34003 | pack cycle count | int16. Pack 1's value (34003) is already integrated as `battery_cycle_count`. |
 | 34004 | pack MOS status | u8. BMS charge/discharge MOSFET state (Chg/Dsg MOS). |
-| 34005 | pack max cell voltage | uint16, scale 0.001 V. |
-| 34006 | pack min cell voltage | uint16, scale 0.001 V. |
+| 34005 | pack max cell voltage | uint16, scale 0.001 V. **Integrated** as `battery_N_max_cell_voltage`. |
+| 34006 | pack min cell voltage | uint16, scale 0.001 V. **Integrated** as `battery_N_min_cell_voltage`. |
 | 34007 | pack protection bitmask 1 | int16 bitmask (BMS CAN frame 0x23, protect1). **Integrated** as `battery_N_protection_1`. |
 | 34008 | pack protection bitmask 2 | uint16 bitmask (frame 0x23, protect2). A low-SoC/undervoltage bit (0x0002) was observed here during discharge testing (triggers below ~10.7%). **Integrated** as `battery_N_protection_2`. |
 | 34009 | pack BMS reserved | uint16. BMS-struct field @+0x5a; not named in the firmware debug print. |
 | 34010 | pack BMS version | uint16. 116 → 1177 (v117.7) after BMS firmware update. |
 | 34011 | pack ENV NTC (ambient) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 0". **Integrated** as `battery_N_env_temperature`. |
 | 34012 | pack MOS NTC (MOSFET) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 1". **Integrated** as `battery_N_mos_temperature`. |
-| 34013–34016 | pack cell NTC block | uint16 ×4, scale 0.1 °C (pack struct +0x40). |
+| 34013–34016 | pack cell NTC block | uint16 ×4, scale 0.1 °C (pack struct +0x40). **Integrated** as `battery_N_cell_temperature_1..4`. |
 | 34017 | pack NTC (unused) | uint16, scale 0.1 °C. BMS frame 0x41 bytes 6–7 are not populated. |
 
 ### Backup / UPS output (verified — candidates for integration)

--- a/custom_components/marstek_modbus/registers/README.md
+++ b/custom_components/marstek_modbus/registers/README.md
@@ -82,26 +82,24 @@ Venus D packs carry 16 cells vs. 13 on Venus A), `alarm_status` (36000), `fault_
 
 Pattern: each pack is offset by +0x100 (pack 1 = 340xx, pack 2 = 341xx, …). Values below confirmed
 across packs 1–5 (pack 6 follows the same pattern; populated only when a 6th pack is present).
+Layout updated per the 2026-08-16 firmware descriptor-table correction (BMS CAN frames 0x23 / 0x41).
 
 | Register (pack 1 / +0x100 per pack) | Key | Notes |
 |----------|-----|-------|
 | 34000 | pack battery voltage | uint16, scale 0.01 V. |
 | 34001 | pack battery current | int16, scale 0.1 A. Negative = discharge. Reads the active pack's current. |
-| 34003 | pack cycle count | uint16. Pack 1's value (34003) is already integrated as `battery_cycle_count`. |
-| 34004 | pack charge status | uint16. 3 = actively charging, 0 = idle. |
+| 34003 | pack cycle count | int16. Pack 1's value (34003) is already integrated as `battery_cycle_count`. |
+| 34004 | pack MOS status | u8. BMS charge/discharge MOSFET state (Chg/Dsg MOS). |
 | 34005 | pack max cell voltage | uint16, scale 0.001 V. |
 | 34006 | pack min cell voltage | uint16, scale 0.001 V. |
-| 34007 | pack max NTC temperature | uint16, scale 0.1 °C. |
-| 34008 | pack protection bitmask 1 | uint16 bitmask. Individual bits not fully decoded. |
-| 34009 | pack protection bitmask 2 | uint16 bitmask. Bit 1 (0x0002) = low-SoC/undervoltage (confirmed in discharge test, triggers below ~10.7%). |
+| 34007 | pack protection bitmask 1 | int16 bitmask (BMS CAN frame 0x23, protect1). |
+| 34008 | pack protection bitmask 2 | uint16 bitmask (frame 0x23, protect2). A low-SoC/undervoltage bit (0x0002) was observed here during discharge testing (triggers below ~10.7%). |
+| 34009 | pack BMS reserved | uint16. BMS-struct field @+0x5a; not named in the firmware debug print. |
 | 34010 | pack BMS version | uint16. 116 → 1177 (v117.7) after BMS firmware update. |
-| 34011 | pack cell NTC 0 | uint16, scale 0.1 °C. |
-| 34012 | pack cell NTC 1 | uint16, scale 0.1 °C. |
-| 34013 | pack cell NTC 2 | uint16, scale 0.1 °C. |
-| 34014 | pack cell NTC 3 | uint16, scale 0.1 °C. |
-| 34015 | pack MOS NTC | uint16, scale 0.1 °C. |
-| 34016 | pack environment NTC | uint16, scale 0.1 °C. |
-| 34017 | pack average NTC | uint16, scale 0.1 °C. |
+| 34011 | pack ENV NTC (ambient) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 0". |
+| 34012 | pack MOS NTC (MOSFET) | uint16, scale 0.1 °C (BMS frame 0x41). Was previously labelled "cell NTC 1". |
+| 34013–34016 | pack cell NTC block | uint16 ×4, scale 0.1 °C (pack struct +0x40). |
+| 34017 | pack NTC (unused) | uint16, scale 0.1 °C. BMS frame 0x41 bytes 6–7 are not populated. |
 
 ### Backup / UPS output (verified — candidates for integration)
 

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1411,6 +1411,367 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: high
+    # --- Per-pack cell voltage extremes and cell NTC block (firmware-confirmed) ---
+    battery_1_max_cell_voltage:
+        register: 34005
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_min_cell_voltage:
+        register: 34006
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_cell_temperature_1:
+        register: 34013
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_cell_temperature_2:
+        register: 34014
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_cell_temperature_3:
+        register: 34015
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_cell_temperature_4:
+        register: 34016
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_max_cell_voltage:
+        register: 34105
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_min_cell_voltage:
+        register: 34106
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_cell_temperature_1:
+        register: 34113
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_cell_temperature_2:
+        register: 34114
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_cell_temperature_3:
+        register: 34115
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_cell_temperature_4:
+        register: 34116
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_max_cell_voltage:
+        register: 34205
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_min_cell_voltage:
+        register: 34206
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_cell_temperature_1:
+        register: 34213
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_cell_temperature_2:
+        register: 34214
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_cell_temperature_3:
+        register: 34215
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_cell_temperature_4:
+        register: 34216
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_max_cell_voltage:
+        register: 34305
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_min_cell_voltage:
+        register: 34306
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_cell_temperature_1:
+        register: 34313
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_cell_temperature_2:
+        register: 34314
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_cell_temperature_3:
+        register: 34315
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_cell_temperature_4:
+        register: 34316
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_max_cell_voltage:
+        register: 34405
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_min_cell_voltage:
+        register: 34406
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_cell_temperature_1:
+        register: 34413
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_cell_temperature_2:
+        register: 34414
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_cell_temperature_3:
+        register: 34415
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_cell_temperature_4:
+        register: 34416
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_max_cell_voltage:
+        register: 34505
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_min_cell_voltage:
+        register: 34506
+        scale: 0.001
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 3
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_cell_temperature_1:
+        register: 34513
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_cell_temperature_2:
+        register: 34514
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_cell_temperature_3:
+        register: 34515
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_cell_temperature_4:
+        register: 34516
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1772,6 +1772,131 @@ SENSOR_DEFINITIONS:
         precision: 1
         enabled_by_default: false
         scan_interval: low
+    # --- Per-pack cycle count, MOS status and BMS version (firmware-confirmed) ---
+    battery_1_mos_status:
+        register: 34004
+        data_type: uint16
+        icon: "mdi:electric-switch"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_1_bms_version:
+        register: 34010
+        data_type: uint16
+        icon: "mdi:battery-check-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_cycle_count:
+        register: 34103
+        data_type: int16
+        state_class: measurement
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_mos_status:
+        register: 34104
+        data_type: uint16
+        icon: "mdi:electric-switch"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_2_bms_version:
+        register: 34110
+        data_type: uint16
+        icon: "mdi:battery-check-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_cycle_count:
+        register: 34203
+        data_type: int16
+        state_class: measurement
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_mos_status:
+        register: 34204
+        data_type: uint16
+        icon: "mdi:electric-switch"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_3_bms_version:
+        register: 34210
+        data_type: uint16
+        icon: "mdi:battery-check-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_cycle_count:
+        register: 34303
+        data_type: int16
+        state_class: measurement
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_mos_status:
+        register: 34304
+        data_type: uint16
+        icon: "mdi:electric-switch"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_4_bms_version:
+        register: 34310
+        data_type: uint16
+        icon: "mdi:battery-check-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_cycle_count:
+        register: 34403
+        data_type: int16
+        state_class: measurement
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_mos_status:
+        register: 34404
+        data_type: uint16
+        icon: "mdi:electric-switch"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_5_bms_version:
+        register: 34410
+        data_type: uint16
+        icon: "mdi:battery-check-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_cycle_count:
+        register: 34503
+        data_type: int16
+        state_class: measurement
+        icon: "mdi:counter"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_mos_status:
+        register: 34504
+        data_type: uint16
+        icon: "mdi:electric-switch"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_6_bms_version:
+        register: 34510
+        data_type: uint16
+        icon: "mdi:battery-check-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1206,6 +1206,211 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: high
+    # --- Per-pack temperatures and protection bitmasks (firmware-confirmed 2026-08-16) ---
+    battery_1_env_temperature:
+        register: 34011
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_mos_temperature:
+        register: 34012
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_1_protection_1:
+        register: 34007
+        data_type: int16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_1_protection_2:
+        register: 34008
+        data_type: uint16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_2_env_temperature:
+        register: 34111
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_mos_temperature:
+        register: 34112
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_protection_1:
+        register: 34107
+        data_type: int16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_2_protection_2:
+        register: 34108
+        data_type: uint16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_3_env_temperature:
+        register: 34211
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_mos_temperature:
+        register: 34212
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_protection_1:
+        register: 34207
+        data_type: int16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_3_protection_2:
+        register: 34208
+        data_type: uint16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_4_env_temperature:
+        register: 34311
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_mos_temperature:
+        register: 34312
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_protection_1:
+        register: 34307
+        data_type: int16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_4_protection_2:
+        register: 34308
+        data_type: uint16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_5_env_temperature:
+        register: 34411
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_mos_temperature:
+        register: 34412
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_protection_1:
+        register: 34407
+        data_type: int16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_5_protection_2:
+        register: 34408
+        data_type: uint16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_6_env_temperature:
+        register: 34511
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_mos_temperature:
+        register: 34512
+        scale: 0.1
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        data_type: uint16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_protection_1:
+        register: 34507
+        data_type: int16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    battery_6_protection_2:
+        register: 34508
+        data_type: uint16
+        icon: "mdi:shield-alert-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/registers/d.yaml
+++ b/custom_components/marstek_modbus/registers/d.yaml
@@ -1897,6 +1897,129 @@ SENSOR_DEFINITIONS:
         category: diagnostic
         enabled_by_default: false
         scan_interval: low
+    # --- Per-pack terminal voltage / current (packs 2-6; pack 1 = battery_voltage/current) ---
+    battery_2_voltage:
+        register: 34100
+        scale: 0.01
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 2
+        enabled_by_default: false
+        scan_interval: low
+    battery_2_current:
+        register: 34101
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        data_type: int16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_voltage:
+        register: 34200
+        scale: 0.01
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 2
+        enabled_by_default: false
+        scan_interval: low
+    battery_3_current:
+        register: 34201
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        data_type: int16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_voltage:
+        register: 34300
+        scale: 0.01
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 2
+        enabled_by_default: false
+        scan_interval: low
+    battery_4_current:
+        register: 34301
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        data_type: int16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_voltage:
+        register: 34400
+        scale: 0.01
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 2
+        enabled_by_default: false
+        scan_interval: low
+    battery_5_current:
+        register: 34401
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        data_type: int16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_voltage:
+        register: 34500
+        scale: 0.01
+        unit: V
+        device_class: voltage
+        state_class: measurement
+        data_type: uint16
+        precision: 2
+        enabled_by_default: false
+        scan_interval: low
+    battery_6_current:
+        register: 34501
+        scale: 0.1
+        unit: A
+        device_class: current
+        state_class: measurement
+        data_type: int16
+        precision: 1
+        enabled_by_default: false
+        scan_interval: low
+    # --- System diagnostics (firmware-decoded) ---
+    work_mode:
+        register: 30010
+        data_type: uint16
+        icon: "mdi:cog-outline"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: high
+    ems_boot_version:
+        register: 30201
+        data_type: uint16
+        icon: "mdi:chip"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
+    vns_boot_version:
+        register: 30203
+        data_type: uint16
+        icon: "mdi:chip"
+        category: diagnostic
+        enabled_by_default: false
+        scan_interval: low
 
 BINARY_SENSOR_DEFINITIONS:
     wifi_status:

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -63,6 +63,78 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_env_temperature": {
+        "name": "Batteriepack 1 Umgebungstemperatur"
+      },
+      "battery_1_mos_temperature": {
+        "name": "Batteriepack 1 MOSFET-Temperatur"
+      },
+      "battery_1_protection_1": {
+        "name": "Batteriepack 1 Schutz 1"
+      },
+      "battery_1_protection_2": {
+        "name": "Batteriepack 1 Schutz 2"
+      },
+      "battery_2_env_temperature": {
+        "name": "Batteriepack 2 Umgebungstemperatur"
+      },
+      "battery_2_mos_temperature": {
+        "name": "Batteriepack 2 MOSFET-Temperatur"
+      },
+      "battery_2_protection_1": {
+        "name": "Batteriepack 2 Schutz 1"
+      },
+      "battery_2_protection_2": {
+        "name": "Batteriepack 2 Schutz 2"
+      },
+      "battery_3_env_temperature": {
+        "name": "Batteriepack 3 Umgebungstemperatur"
+      },
+      "battery_3_mos_temperature": {
+        "name": "Batteriepack 3 MOSFET-Temperatur"
+      },
+      "battery_3_protection_1": {
+        "name": "Batteriepack 3 Schutz 1"
+      },
+      "battery_3_protection_2": {
+        "name": "Batteriepack 3 Schutz 2"
+      },
+      "battery_4_env_temperature": {
+        "name": "Batteriepack 4 Umgebungstemperatur"
+      },
+      "battery_4_mos_temperature": {
+        "name": "Batteriepack 4 MOSFET-Temperatur"
+      },
+      "battery_4_protection_1": {
+        "name": "Batteriepack 4 Schutz 1"
+      },
+      "battery_4_protection_2": {
+        "name": "Batteriepack 4 Schutz 2"
+      },
+      "battery_5_env_temperature": {
+        "name": "Batteriepack 5 Umgebungstemperatur"
+      },
+      "battery_5_mos_temperature": {
+        "name": "Batteriepack 5 MOSFET-Temperatur"
+      },
+      "battery_5_protection_1": {
+        "name": "Batteriepack 5 Schutz 1"
+      },
+      "battery_5_protection_2": {
+        "name": "Batteriepack 5 Schutz 2"
+      },
+      "battery_6_env_temperature": {
+        "name": "Batteriepack 6 Umgebungstemperatur"
+      },
+      "battery_6_mos_temperature": {
+        "name": "Batteriepack 6 MOSFET-Temperatur"
+      },
+      "battery_6_protection_1": {
+        "name": "Batteriepack 6 Schutz 1"
+      },
+      "battery_6_protection_2": {
+        "name": "Batteriepack 6 Schutz 2"
+      },
       "device_name": {
         "name": "Gerätename"
       },

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -63,6 +63,45 @@
   },
   "entity": {
     "sensor": {
+      "battery_2_voltage": {
+        "name": "Batteriepack 2 Spannung"
+      },
+      "battery_2_current": {
+        "name": "Batteriepack 2 Strom"
+      },
+      "battery_3_voltage": {
+        "name": "Batteriepack 3 Spannung"
+      },
+      "battery_3_current": {
+        "name": "Batteriepack 3 Strom"
+      },
+      "battery_4_voltage": {
+        "name": "Batteriepack 4 Spannung"
+      },
+      "battery_4_current": {
+        "name": "Batteriepack 4 Strom"
+      },
+      "battery_5_voltage": {
+        "name": "Batteriepack 5 Spannung"
+      },
+      "battery_5_current": {
+        "name": "Batteriepack 5 Strom"
+      },
+      "battery_6_voltage": {
+        "name": "Batteriepack 6 Spannung"
+      },
+      "battery_6_current": {
+        "name": "Batteriepack 6 Strom"
+      },
+      "work_mode": {
+        "name": "Betriebsmodus"
+      },
+      "ems_boot_version": {
+        "name": "EMS-Bootloader-Version"
+      },
+      "vns_boot_version": {
+        "name": "VNS-Bootloader-Version"
+      },
       "battery_1_mos_status": {
         "name": "Batteriepack 1 MOSFET-Status"
       },

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -63,6 +63,57 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_mos_status": {
+        "name": "Batteriepack 1 MOSFET-Status"
+      },
+      "battery_1_bms_version": {
+        "name": "Batteriepack 1 BMS-Version"
+      },
+      "battery_2_cycle_count": {
+        "name": "Batteriepack 2 Zyklenzahl"
+      },
+      "battery_2_mos_status": {
+        "name": "Batteriepack 2 MOSFET-Status"
+      },
+      "battery_2_bms_version": {
+        "name": "Batteriepack 2 BMS-Version"
+      },
+      "battery_3_cycle_count": {
+        "name": "Batteriepack 3 Zyklenzahl"
+      },
+      "battery_3_mos_status": {
+        "name": "Batteriepack 3 MOSFET-Status"
+      },
+      "battery_3_bms_version": {
+        "name": "Batteriepack 3 BMS-Version"
+      },
+      "battery_4_cycle_count": {
+        "name": "Batteriepack 4 Zyklenzahl"
+      },
+      "battery_4_mos_status": {
+        "name": "Batteriepack 4 MOSFET-Status"
+      },
+      "battery_4_bms_version": {
+        "name": "Batteriepack 4 BMS-Version"
+      },
+      "battery_5_cycle_count": {
+        "name": "Batteriepack 5 Zyklenzahl"
+      },
+      "battery_5_mos_status": {
+        "name": "Batteriepack 5 MOSFET-Status"
+      },
+      "battery_5_bms_version": {
+        "name": "Batteriepack 5 BMS-Version"
+      },
+      "battery_6_cycle_count": {
+        "name": "Batteriepack 6 Zyklenzahl"
+      },
+      "battery_6_mos_status": {
+        "name": "Batteriepack 6 MOSFET-Status"
+      },
+      "battery_6_bms_version": {
+        "name": "Batteriepack 6 BMS-Version"
+      },
       "battery_1_max_cell_voltage": {
         "name": "Batteriepack 1 max. Zellspannung"
       },

--- a/custom_components/marstek_modbus/translations/de.json
+++ b/custom_components/marstek_modbus/translations/de.json
@@ -63,6 +63,114 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_max_cell_voltage": {
+        "name": "Batteriepack 1 max. Zellspannung"
+      },
+      "battery_1_min_cell_voltage": {
+        "name": "Batteriepack 1 min. Zellspannung"
+      },
+      "battery_1_cell_temperature_1": {
+        "name": "Batteriepack 1 Zelltemperatur 1"
+      },
+      "battery_1_cell_temperature_2": {
+        "name": "Batteriepack 1 Zelltemperatur 2"
+      },
+      "battery_1_cell_temperature_3": {
+        "name": "Batteriepack 1 Zelltemperatur 3"
+      },
+      "battery_1_cell_temperature_4": {
+        "name": "Batteriepack 1 Zelltemperatur 4"
+      },
+      "battery_2_max_cell_voltage": {
+        "name": "Batteriepack 2 max. Zellspannung"
+      },
+      "battery_2_min_cell_voltage": {
+        "name": "Batteriepack 2 min. Zellspannung"
+      },
+      "battery_2_cell_temperature_1": {
+        "name": "Batteriepack 2 Zelltemperatur 1"
+      },
+      "battery_2_cell_temperature_2": {
+        "name": "Batteriepack 2 Zelltemperatur 2"
+      },
+      "battery_2_cell_temperature_3": {
+        "name": "Batteriepack 2 Zelltemperatur 3"
+      },
+      "battery_2_cell_temperature_4": {
+        "name": "Batteriepack 2 Zelltemperatur 4"
+      },
+      "battery_3_max_cell_voltage": {
+        "name": "Batteriepack 3 max. Zellspannung"
+      },
+      "battery_3_min_cell_voltage": {
+        "name": "Batteriepack 3 min. Zellspannung"
+      },
+      "battery_3_cell_temperature_1": {
+        "name": "Batteriepack 3 Zelltemperatur 1"
+      },
+      "battery_3_cell_temperature_2": {
+        "name": "Batteriepack 3 Zelltemperatur 2"
+      },
+      "battery_3_cell_temperature_3": {
+        "name": "Batteriepack 3 Zelltemperatur 3"
+      },
+      "battery_3_cell_temperature_4": {
+        "name": "Batteriepack 3 Zelltemperatur 4"
+      },
+      "battery_4_max_cell_voltage": {
+        "name": "Batteriepack 4 max. Zellspannung"
+      },
+      "battery_4_min_cell_voltage": {
+        "name": "Batteriepack 4 min. Zellspannung"
+      },
+      "battery_4_cell_temperature_1": {
+        "name": "Batteriepack 4 Zelltemperatur 1"
+      },
+      "battery_4_cell_temperature_2": {
+        "name": "Batteriepack 4 Zelltemperatur 2"
+      },
+      "battery_4_cell_temperature_3": {
+        "name": "Batteriepack 4 Zelltemperatur 3"
+      },
+      "battery_4_cell_temperature_4": {
+        "name": "Batteriepack 4 Zelltemperatur 4"
+      },
+      "battery_5_max_cell_voltage": {
+        "name": "Batteriepack 5 max. Zellspannung"
+      },
+      "battery_5_min_cell_voltage": {
+        "name": "Batteriepack 5 min. Zellspannung"
+      },
+      "battery_5_cell_temperature_1": {
+        "name": "Batteriepack 5 Zelltemperatur 1"
+      },
+      "battery_5_cell_temperature_2": {
+        "name": "Batteriepack 5 Zelltemperatur 2"
+      },
+      "battery_5_cell_temperature_3": {
+        "name": "Batteriepack 5 Zelltemperatur 3"
+      },
+      "battery_5_cell_temperature_4": {
+        "name": "Batteriepack 5 Zelltemperatur 4"
+      },
+      "battery_6_max_cell_voltage": {
+        "name": "Batteriepack 6 max. Zellspannung"
+      },
+      "battery_6_min_cell_voltage": {
+        "name": "Batteriepack 6 min. Zellspannung"
+      },
+      "battery_6_cell_temperature_1": {
+        "name": "Batteriepack 6 Zelltemperatur 1"
+      },
+      "battery_6_cell_temperature_2": {
+        "name": "Batteriepack 6 Zelltemperatur 2"
+      },
+      "battery_6_cell_temperature_3": {
+        "name": "Batteriepack 6 Zelltemperatur 3"
+      },
+      "battery_6_cell_temperature_4": {
+        "name": "Batteriepack 6 Zelltemperatur 4"
+      },
       "battery_1_env_temperature": {
         "name": "Batteriepack 1 Umgebungstemperatur"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -63,6 +63,57 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_mos_status": {
+        "name": "Battery Pack 1 MOS Status"
+      },
+      "battery_1_bms_version": {
+        "name": "Battery Pack 1 BMS Version"
+      },
+      "battery_2_cycle_count": {
+        "name": "Battery Pack 2 Cycle Count"
+      },
+      "battery_2_mos_status": {
+        "name": "Battery Pack 2 MOS Status"
+      },
+      "battery_2_bms_version": {
+        "name": "Battery Pack 2 BMS Version"
+      },
+      "battery_3_cycle_count": {
+        "name": "Battery Pack 3 Cycle Count"
+      },
+      "battery_3_mos_status": {
+        "name": "Battery Pack 3 MOS Status"
+      },
+      "battery_3_bms_version": {
+        "name": "Battery Pack 3 BMS Version"
+      },
+      "battery_4_cycle_count": {
+        "name": "Battery Pack 4 Cycle Count"
+      },
+      "battery_4_mos_status": {
+        "name": "Battery Pack 4 MOS Status"
+      },
+      "battery_4_bms_version": {
+        "name": "Battery Pack 4 BMS Version"
+      },
+      "battery_5_cycle_count": {
+        "name": "Battery Pack 5 Cycle Count"
+      },
+      "battery_5_mos_status": {
+        "name": "Battery Pack 5 MOS Status"
+      },
+      "battery_5_bms_version": {
+        "name": "Battery Pack 5 BMS Version"
+      },
+      "battery_6_cycle_count": {
+        "name": "Battery Pack 6 Cycle Count"
+      },
+      "battery_6_mos_status": {
+        "name": "Battery Pack 6 MOS Status"
+      },
+      "battery_6_bms_version": {
+        "name": "Battery Pack 6 BMS Version"
+      },
       "battery_1_max_cell_voltage": {
         "name": "Battery Pack 1 Max Cell Voltage"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -63,6 +63,78 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_env_temperature": {
+        "name": "Battery Pack 1 Ambient Temperature"
+      },
+      "battery_1_mos_temperature": {
+        "name": "Battery Pack 1 MOSFET Temperature"
+      },
+      "battery_1_protection_1": {
+        "name": "Battery Pack 1 Protection 1"
+      },
+      "battery_1_protection_2": {
+        "name": "Battery Pack 1 Protection 2"
+      },
+      "battery_2_env_temperature": {
+        "name": "Battery Pack 2 Ambient Temperature"
+      },
+      "battery_2_mos_temperature": {
+        "name": "Battery Pack 2 MOSFET Temperature"
+      },
+      "battery_2_protection_1": {
+        "name": "Battery Pack 2 Protection 1"
+      },
+      "battery_2_protection_2": {
+        "name": "Battery Pack 2 Protection 2"
+      },
+      "battery_3_env_temperature": {
+        "name": "Battery Pack 3 Ambient Temperature"
+      },
+      "battery_3_mos_temperature": {
+        "name": "Battery Pack 3 MOSFET Temperature"
+      },
+      "battery_3_protection_1": {
+        "name": "Battery Pack 3 Protection 1"
+      },
+      "battery_3_protection_2": {
+        "name": "Battery Pack 3 Protection 2"
+      },
+      "battery_4_env_temperature": {
+        "name": "Battery Pack 4 Ambient Temperature"
+      },
+      "battery_4_mos_temperature": {
+        "name": "Battery Pack 4 MOSFET Temperature"
+      },
+      "battery_4_protection_1": {
+        "name": "Battery Pack 4 Protection 1"
+      },
+      "battery_4_protection_2": {
+        "name": "Battery Pack 4 Protection 2"
+      },
+      "battery_5_env_temperature": {
+        "name": "Battery Pack 5 Ambient Temperature"
+      },
+      "battery_5_mos_temperature": {
+        "name": "Battery Pack 5 MOSFET Temperature"
+      },
+      "battery_5_protection_1": {
+        "name": "Battery Pack 5 Protection 1"
+      },
+      "battery_5_protection_2": {
+        "name": "Battery Pack 5 Protection 2"
+      },
+      "battery_6_env_temperature": {
+        "name": "Battery Pack 6 Ambient Temperature"
+      },
+      "battery_6_mos_temperature": {
+        "name": "Battery Pack 6 MOSFET Temperature"
+      },
+      "battery_6_protection_1": {
+        "name": "Battery Pack 6 Protection 1"
+      },
+      "battery_6_protection_2": {
+        "name": "Battery Pack 6 Protection 2"
+      },
       "device_name": {
         "name": "Device Name"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -63,6 +63,114 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_max_cell_voltage": {
+        "name": "Battery Pack 1 Max Cell Voltage"
+      },
+      "battery_1_min_cell_voltage": {
+        "name": "Battery Pack 1 Min Cell Voltage"
+      },
+      "battery_1_cell_temperature_1": {
+        "name": "Battery Pack 1 Cell Temperature 1"
+      },
+      "battery_1_cell_temperature_2": {
+        "name": "Battery Pack 1 Cell Temperature 2"
+      },
+      "battery_1_cell_temperature_3": {
+        "name": "Battery Pack 1 Cell Temperature 3"
+      },
+      "battery_1_cell_temperature_4": {
+        "name": "Battery Pack 1 Cell Temperature 4"
+      },
+      "battery_2_max_cell_voltage": {
+        "name": "Battery Pack 2 Max Cell Voltage"
+      },
+      "battery_2_min_cell_voltage": {
+        "name": "Battery Pack 2 Min Cell Voltage"
+      },
+      "battery_2_cell_temperature_1": {
+        "name": "Battery Pack 2 Cell Temperature 1"
+      },
+      "battery_2_cell_temperature_2": {
+        "name": "Battery Pack 2 Cell Temperature 2"
+      },
+      "battery_2_cell_temperature_3": {
+        "name": "Battery Pack 2 Cell Temperature 3"
+      },
+      "battery_2_cell_temperature_4": {
+        "name": "Battery Pack 2 Cell Temperature 4"
+      },
+      "battery_3_max_cell_voltage": {
+        "name": "Battery Pack 3 Max Cell Voltage"
+      },
+      "battery_3_min_cell_voltage": {
+        "name": "Battery Pack 3 Min Cell Voltage"
+      },
+      "battery_3_cell_temperature_1": {
+        "name": "Battery Pack 3 Cell Temperature 1"
+      },
+      "battery_3_cell_temperature_2": {
+        "name": "Battery Pack 3 Cell Temperature 2"
+      },
+      "battery_3_cell_temperature_3": {
+        "name": "Battery Pack 3 Cell Temperature 3"
+      },
+      "battery_3_cell_temperature_4": {
+        "name": "Battery Pack 3 Cell Temperature 4"
+      },
+      "battery_4_max_cell_voltage": {
+        "name": "Battery Pack 4 Max Cell Voltage"
+      },
+      "battery_4_min_cell_voltage": {
+        "name": "Battery Pack 4 Min Cell Voltage"
+      },
+      "battery_4_cell_temperature_1": {
+        "name": "Battery Pack 4 Cell Temperature 1"
+      },
+      "battery_4_cell_temperature_2": {
+        "name": "Battery Pack 4 Cell Temperature 2"
+      },
+      "battery_4_cell_temperature_3": {
+        "name": "Battery Pack 4 Cell Temperature 3"
+      },
+      "battery_4_cell_temperature_4": {
+        "name": "Battery Pack 4 Cell Temperature 4"
+      },
+      "battery_5_max_cell_voltage": {
+        "name": "Battery Pack 5 Max Cell Voltage"
+      },
+      "battery_5_min_cell_voltage": {
+        "name": "Battery Pack 5 Min Cell Voltage"
+      },
+      "battery_5_cell_temperature_1": {
+        "name": "Battery Pack 5 Cell Temperature 1"
+      },
+      "battery_5_cell_temperature_2": {
+        "name": "Battery Pack 5 Cell Temperature 2"
+      },
+      "battery_5_cell_temperature_3": {
+        "name": "Battery Pack 5 Cell Temperature 3"
+      },
+      "battery_5_cell_temperature_4": {
+        "name": "Battery Pack 5 Cell Temperature 4"
+      },
+      "battery_6_max_cell_voltage": {
+        "name": "Battery Pack 6 Max Cell Voltage"
+      },
+      "battery_6_min_cell_voltage": {
+        "name": "Battery Pack 6 Min Cell Voltage"
+      },
+      "battery_6_cell_temperature_1": {
+        "name": "Battery Pack 6 Cell Temperature 1"
+      },
+      "battery_6_cell_temperature_2": {
+        "name": "Battery Pack 6 Cell Temperature 2"
+      },
+      "battery_6_cell_temperature_3": {
+        "name": "Battery Pack 6 Cell Temperature 3"
+      },
+      "battery_6_cell_temperature_4": {
+        "name": "Battery Pack 6 Cell Temperature 4"
+      },
       "battery_1_env_temperature": {
         "name": "Battery Pack 1 Ambient Temperature"
       },

--- a/custom_components/marstek_modbus/translations/en.json
+++ b/custom_components/marstek_modbus/translations/en.json
@@ -63,6 +63,45 @@
   },
   "entity": {
     "sensor": {
+      "battery_2_voltage": {
+        "name": "Battery Pack 2 Voltage"
+      },
+      "battery_2_current": {
+        "name": "Battery Pack 2 Current"
+      },
+      "battery_3_voltage": {
+        "name": "Battery Pack 3 Voltage"
+      },
+      "battery_3_current": {
+        "name": "Battery Pack 3 Current"
+      },
+      "battery_4_voltage": {
+        "name": "Battery Pack 4 Voltage"
+      },
+      "battery_4_current": {
+        "name": "Battery Pack 4 Current"
+      },
+      "battery_5_voltage": {
+        "name": "Battery Pack 5 Voltage"
+      },
+      "battery_5_current": {
+        "name": "Battery Pack 5 Current"
+      },
+      "battery_6_voltage": {
+        "name": "Battery Pack 6 Voltage"
+      },
+      "battery_6_current": {
+        "name": "Battery Pack 6 Current"
+      },
+      "work_mode": {
+        "name": "Work Mode"
+      },
+      "ems_boot_version": {
+        "name": "EMS Bootloader Version"
+      },
+      "vns_boot_version": {
+        "name": "VNS Bootloader Version"
+      },
       "battery_1_mos_status": {
         "name": "Battery Pack 1 MOS Status"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -67,6 +67,57 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_mos_status": {
+        "name": "Batterij pack 1 MOSFET-status"
+      },
+      "battery_1_bms_version": {
+        "name": "Batterij pack 1 BMS-versie"
+      },
+      "battery_2_cycle_count": {
+        "name": "Batterij pack 2 Cyclusaantal"
+      },
+      "battery_2_mos_status": {
+        "name": "Batterij pack 2 MOSFET-status"
+      },
+      "battery_2_bms_version": {
+        "name": "Batterij pack 2 BMS-versie"
+      },
+      "battery_3_cycle_count": {
+        "name": "Batterij pack 3 Cyclusaantal"
+      },
+      "battery_3_mos_status": {
+        "name": "Batterij pack 3 MOSFET-status"
+      },
+      "battery_3_bms_version": {
+        "name": "Batterij pack 3 BMS-versie"
+      },
+      "battery_4_cycle_count": {
+        "name": "Batterij pack 4 Cyclusaantal"
+      },
+      "battery_4_mos_status": {
+        "name": "Batterij pack 4 MOSFET-status"
+      },
+      "battery_4_bms_version": {
+        "name": "Batterij pack 4 BMS-versie"
+      },
+      "battery_5_cycle_count": {
+        "name": "Batterij pack 5 Cyclusaantal"
+      },
+      "battery_5_mos_status": {
+        "name": "Batterij pack 5 MOSFET-status"
+      },
+      "battery_5_bms_version": {
+        "name": "Batterij pack 5 BMS-versie"
+      },
+      "battery_6_cycle_count": {
+        "name": "Batterij pack 6 Cyclusaantal"
+      },
+      "battery_6_mos_status": {
+        "name": "Batterij pack 6 MOSFET-status"
+      },
+      "battery_6_bms_version": {
+        "name": "Batterij pack 6 BMS-versie"
+      },
       "battery_1_max_cell_voltage": {
         "name": "Batterij pack 1 Max celspanning"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -67,6 +67,45 @@
   },
   "entity": {
     "sensor": {
+      "battery_2_voltage": {
+        "name": "Batterij pack 2 Spanning"
+      },
+      "battery_2_current": {
+        "name": "Batterij pack 2 Stroom"
+      },
+      "battery_3_voltage": {
+        "name": "Batterij pack 3 Spanning"
+      },
+      "battery_3_current": {
+        "name": "Batterij pack 3 Stroom"
+      },
+      "battery_4_voltage": {
+        "name": "Batterij pack 4 Spanning"
+      },
+      "battery_4_current": {
+        "name": "Batterij pack 4 Stroom"
+      },
+      "battery_5_voltage": {
+        "name": "Batterij pack 5 Spanning"
+      },
+      "battery_5_current": {
+        "name": "Batterij pack 5 Stroom"
+      },
+      "battery_6_voltage": {
+        "name": "Batterij pack 6 Spanning"
+      },
+      "battery_6_current": {
+        "name": "Batterij pack 6 Stroom"
+      },
+      "work_mode": {
+        "name": "Werkmodus"
+      },
+      "ems_boot_version": {
+        "name": "EMS-bootloaderversie"
+      },
+      "vns_boot_version": {
+        "name": "VNS-bootloaderversie"
+      },
       "battery_1_mos_status": {
         "name": "Batterij pack 1 MOSFET-status"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -67,6 +67,114 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_max_cell_voltage": {
+        "name": "Batterij pack 1 Max celspanning"
+      },
+      "battery_1_min_cell_voltage": {
+        "name": "Batterij pack 1 Min celspanning"
+      },
+      "battery_1_cell_temperature_1": {
+        "name": "Batterij pack 1 Celtemperatuur 1"
+      },
+      "battery_1_cell_temperature_2": {
+        "name": "Batterij pack 1 Celtemperatuur 2"
+      },
+      "battery_1_cell_temperature_3": {
+        "name": "Batterij pack 1 Celtemperatuur 3"
+      },
+      "battery_1_cell_temperature_4": {
+        "name": "Batterij pack 1 Celtemperatuur 4"
+      },
+      "battery_2_max_cell_voltage": {
+        "name": "Batterij pack 2 Max celspanning"
+      },
+      "battery_2_min_cell_voltage": {
+        "name": "Batterij pack 2 Min celspanning"
+      },
+      "battery_2_cell_temperature_1": {
+        "name": "Batterij pack 2 Celtemperatuur 1"
+      },
+      "battery_2_cell_temperature_2": {
+        "name": "Batterij pack 2 Celtemperatuur 2"
+      },
+      "battery_2_cell_temperature_3": {
+        "name": "Batterij pack 2 Celtemperatuur 3"
+      },
+      "battery_2_cell_temperature_4": {
+        "name": "Batterij pack 2 Celtemperatuur 4"
+      },
+      "battery_3_max_cell_voltage": {
+        "name": "Batterij pack 3 Max celspanning"
+      },
+      "battery_3_min_cell_voltage": {
+        "name": "Batterij pack 3 Min celspanning"
+      },
+      "battery_3_cell_temperature_1": {
+        "name": "Batterij pack 3 Celtemperatuur 1"
+      },
+      "battery_3_cell_temperature_2": {
+        "name": "Batterij pack 3 Celtemperatuur 2"
+      },
+      "battery_3_cell_temperature_3": {
+        "name": "Batterij pack 3 Celtemperatuur 3"
+      },
+      "battery_3_cell_temperature_4": {
+        "name": "Batterij pack 3 Celtemperatuur 4"
+      },
+      "battery_4_max_cell_voltage": {
+        "name": "Batterij pack 4 Max celspanning"
+      },
+      "battery_4_min_cell_voltage": {
+        "name": "Batterij pack 4 Min celspanning"
+      },
+      "battery_4_cell_temperature_1": {
+        "name": "Batterij pack 4 Celtemperatuur 1"
+      },
+      "battery_4_cell_temperature_2": {
+        "name": "Batterij pack 4 Celtemperatuur 2"
+      },
+      "battery_4_cell_temperature_3": {
+        "name": "Batterij pack 4 Celtemperatuur 3"
+      },
+      "battery_4_cell_temperature_4": {
+        "name": "Batterij pack 4 Celtemperatuur 4"
+      },
+      "battery_5_max_cell_voltage": {
+        "name": "Batterij pack 5 Max celspanning"
+      },
+      "battery_5_min_cell_voltage": {
+        "name": "Batterij pack 5 Min celspanning"
+      },
+      "battery_5_cell_temperature_1": {
+        "name": "Batterij pack 5 Celtemperatuur 1"
+      },
+      "battery_5_cell_temperature_2": {
+        "name": "Batterij pack 5 Celtemperatuur 2"
+      },
+      "battery_5_cell_temperature_3": {
+        "name": "Batterij pack 5 Celtemperatuur 3"
+      },
+      "battery_5_cell_temperature_4": {
+        "name": "Batterij pack 5 Celtemperatuur 4"
+      },
+      "battery_6_max_cell_voltage": {
+        "name": "Batterij pack 6 Max celspanning"
+      },
+      "battery_6_min_cell_voltage": {
+        "name": "Batterij pack 6 Min celspanning"
+      },
+      "battery_6_cell_temperature_1": {
+        "name": "Batterij pack 6 Celtemperatuur 1"
+      },
+      "battery_6_cell_temperature_2": {
+        "name": "Batterij pack 6 Celtemperatuur 2"
+      },
+      "battery_6_cell_temperature_3": {
+        "name": "Batterij pack 6 Celtemperatuur 3"
+      },
+      "battery_6_cell_temperature_4": {
+        "name": "Batterij pack 6 Celtemperatuur 4"
+      },
       "battery_1_env_temperature": {
         "name": "Batterij pack 1 Omgevingstemperatuur"
       },

--- a/custom_components/marstek_modbus/translations/nl.json
+++ b/custom_components/marstek_modbus/translations/nl.json
@@ -67,6 +67,78 @@
   },
   "entity": {
     "sensor": {
+      "battery_1_env_temperature": {
+        "name": "Batterij pack 1 Omgevingstemperatuur"
+      },
+      "battery_1_mos_temperature": {
+        "name": "Batterij pack 1 MOSFET-temperatuur"
+      },
+      "battery_1_protection_1": {
+        "name": "Batterij pack 1 Bescherming 1"
+      },
+      "battery_1_protection_2": {
+        "name": "Batterij pack 1 Bescherming 2"
+      },
+      "battery_2_env_temperature": {
+        "name": "Batterij pack 2 Omgevingstemperatuur"
+      },
+      "battery_2_mos_temperature": {
+        "name": "Batterij pack 2 MOSFET-temperatuur"
+      },
+      "battery_2_protection_1": {
+        "name": "Batterij pack 2 Bescherming 1"
+      },
+      "battery_2_protection_2": {
+        "name": "Batterij pack 2 Bescherming 2"
+      },
+      "battery_3_env_temperature": {
+        "name": "Batterij pack 3 Omgevingstemperatuur"
+      },
+      "battery_3_mos_temperature": {
+        "name": "Batterij pack 3 MOSFET-temperatuur"
+      },
+      "battery_3_protection_1": {
+        "name": "Batterij pack 3 Bescherming 1"
+      },
+      "battery_3_protection_2": {
+        "name": "Batterij pack 3 Bescherming 2"
+      },
+      "battery_4_env_temperature": {
+        "name": "Batterij pack 4 Omgevingstemperatuur"
+      },
+      "battery_4_mos_temperature": {
+        "name": "Batterij pack 4 MOSFET-temperatuur"
+      },
+      "battery_4_protection_1": {
+        "name": "Batterij pack 4 Bescherming 1"
+      },
+      "battery_4_protection_2": {
+        "name": "Batterij pack 4 Bescherming 2"
+      },
+      "battery_5_env_temperature": {
+        "name": "Batterij pack 5 Omgevingstemperatuur"
+      },
+      "battery_5_mos_temperature": {
+        "name": "Batterij pack 5 MOSFET-temperatuur"
+      },
+      "battery_5_protection_1": {
+        "name": "Batterij pack 5 Bescherming 1"
+      },
+      "battery_5_protection_2": {
+        "name": "Batterij pack 5 Bescherming 2"
+      },
+      "battery_6_env_temperature": {
+        "name": "Batterij pack 6 Omgevingstemperatuur"
+      },
+      "battery_6_mos_temperature": {
+        "name": "Batterij pack 6 MOSFET-temperatuur"
+      },
+      "battery_6_protection_1": {
+        "name": "Batterij pack 6 Bescherming 1"
+      },
+      "battery_6_protection_2": {
+        "name": "Batterij pack 6 Bescherming 2"
+      },
       "device_name": {
         "name": "Apparaatnaam"
       },


### PR DESCRIPTION
# Venus D: integrate per-pack health sensors + firmware register documentation

Backed by the 2026-08-16 firmware descriptor-table analysis (BMS CAN frames 0x23 / 0x41), which
confirmed the per-pack register layout. All new sensors are **diagnostic and disabled by default**,
so nothing changes for existing users unless they enable them.

## Per-pack sensors (packs 1–6 unless noted)

| Sensor | Pack 1 register | Notes |
|---|---|---|
| `battery_N_voltage` | 34000 | 0.01 V. Packs 2–6 (pack 1 = `battery_voltage`). |
| `battery_N_current` | 34001 | 0.1 A, int16. Packs 2–6 (pack 1 = `battery_current`). |
| `battery_N_max_cell_voltage` / `battery_N_min_cell_voltage` | 34005 / 34006 | 0.001 V. |
| `battery_N_mos_status` | 34004 | charge/discharge MOSFET state. |
| `battery_N_cycle_count` | 34003 | Packs 2–6 (pack 1 = `battery_cycle_count`). |
| `battery_N_protection_1` / `battery_N_protection_2` | 34007 / 34008 | protection bitmasks; low-SoC bit 0x0002 observed. |
| `battery_N_bms_version` | 34010 | per-pack BMS firmware version. |
| `battery_N_env_temperature` / `battery_N_mos_temperature` | 34011 / 34012 | 0.1 °C. |
| `battery_N_cell_temperature_1..4` | 34013–34016 | 4-element cell NTC block, 0.1 °C. |

## System diagnostics

`work_mode` (30010), `ems_boot_version` (30201), `vns_boot_version` (30203).

## `registers/README.md`

- Corrects the per-pack layout (34004/34007/34008/34009/34011/34012 were mislabelled by the earlier
  scan-based notes) and marks every integrated register family.
- Adds an **"alternative / redundant sources"** section for firmware registers left out on purpose
  because they duplicate values already exposed: `inv_bat_voltage/current` (30028/30029),
  `bms_battery_voltage/current` (32100/32101), `bat_sample_power` (32102),
  `mppt1..4_power` (37017–20 = the already-integrated 30037–40), and the power-limit read-backs
  (37002/37003 = the `max_charge_power` / `max_discharge_power` number entities).

## Quality

- No duplicate register addresses; YAML/JSON validated; en/de/nl translations for every new key.
- Builds on the per-pack layout doc correction (first commit).
